### PR TITLE
Fixes some compiler warnings

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -56,7 +56,7 @@ namespace nanoflann
   *  @{ */
 
   	/** Library version: 0xMmP (M=Major,m=minor,P=patch) */
-	#define NANOFLANN_VERSION 0x118
+	#define NANOFLANN_VERSION 0x119
 
 	/** @addtogroup result_sets_grp Result set classes
 	  *  @{ */


### PR DESCRIPTION
Your response and fast fix of the last issue encouraged me to share back some other small fixes I also did so far.
I'm compiling in a -Wall environment, where unused parameters issue warnings, which tend to jam the console a lot due to all the template magic I put around your library. 
Also I prefer having 0 pointers over pointers with random contents.
