### PR TITLE
A while back with commit f0a31527431f63b88a7d4b5535dc52d70510e199 the…

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1201,7 +1201,7 @@ namespace nanoflann
 		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
 		 */
 		template <class RESULTSET>
-		void searchLevel(RESULTSET& result_set, const ElementType* vec, const NodePtr node, DistanceType &mindistsq,
+		void searchLevel(RESULTSET& result_set, const ElementType* vec, const NodePtr node, DistanceType mindistsq,
 						 distance_vector_t& dists, const float epsError) const
 		{
 			/* If this is a leaf node, then do check and return. */


### PR DESCRIPTION
A while back with commit f0a31527431f63b88a7d4b5535dc52d70510e199 the parameter "mindistsq" of the "searchLevel" method was changed to a reference. This caused a bug since the method calls itself recursively and changes the value of the parameter. As a consequence parts of the tree are wrongfully not traversed while searching which means the search results were not complete. This bug was corrected in this commit.