### PR TITLE
Changes to KDTreeVectorOfVectorsAdaptor to get it to work with STL

### DIFF
--- a/examples/KDTreeVectorOfVectorsAdaptor.h
+++ b/examples/KDTreeVectorOfVectorsAdaptor.h
@@ -51,7 +51,7 @@ struct KDTreeVectorOfVectorsAdaptor
 {
 	typedef KDTreeVectorOfVectorsAdaptor<VectorOfVectorsType,num_t,DIM,Distance> self_t;
 	typedef typename Distance::template traits<num_t,self_t>::distance_t metric_t;
-	typedef KDTreeSingleIndexAdaptor< metric_t,self_t,DIM,IndexType>  index_t;
+	typedef nanoflann::KDTreeSingleIndexAdaptor< metric_t,self_t,DIM,IndexType>  index_t;
 
 	index_t* index; //! The kd-tree index for the user to call its methods as usual with any other FLANN index.
 
@@ -79,7 +79,7 @@ struct KDTreeVectorOfVectorsAdaptor
 	  */
 	inline void query(const num_t *query_point, const size_t num_closest, IndexType *out_indices, num_t *out_distances_sq, const int nChecks_IGNORED = 10) const
 	{
-		nanoflann::KNNResultSet<typename VectorOfVectorsType::Scalar,IndexType> resultSet(num_closest);
+		nanoflann::KNNResultSet<num_t,IndexType> resultSet(num_closest);
 		resultSet.init(out_indices, out_distances_sq);
 		index->findNeighbors(resultSet, query_point, nanoflann::SearchParams());
 	}


### PR DESCRIPTION
`KDTreeVectorOfVectorsAdaptor.h` was originally intended to work with `Eigen::VectorXd`. Changed a couple of lines to make it work with `std::vector<std::vector<double> >` as well.

Changes to `KDTreeVectorOfVectorsAdaptor.h`: 
1. `nanoflann::` added as prefix `KDTreeSingleIndexAdaptor `(line 54) 
2. `::Scalar` changed to `num_t` to work with `std::vector<std::vector<num_t> >`

Code to run an example that uses `std::vector<std::vector<double> >`:
https://gist.github.com/pinaky/741aee0bff40f7ba31c52dc41c3b90b9
You just need `nanoflann.hpp` and `KDTreeVectorOfVectorsAdaptor.h`

**TODO**: tests if this didn't break `Eigen::VectorXd`