### PR TITLE
Bug in RadiusResultSet class

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -184,9 +184,21 @@ namespace nanoflann
 		std::pair<IndexType,DistanceType> worst_item() const
 		{
 		   if (m_indices_dists.empty()) throw std::runtime_error("Cannot invoke RadiusResultSet::worst_item() on an empty list of results.");
-		   typedef typename std::vector<std::pair<IndexType,DistanceType> >::const_iterator DistIt;
-		   DistIt it = std::max_element(m_indices_dists.begin(), m_indices_dists.end());
-		   return *it;
+		   typedef typename std::vector<std::pair<IndexType,DistanceType> >::iterator DistIt;
+		   DistIt it=m_indices_dists.begin();
+		   IndexType index=it->first;
+		   DistanceType dist=it->second;
+		   it++;
+		   while(it!=m_indices_dists.end())
+		   {
+	   		if(it->second>dist)
+	   		{
+	   			dist=it->second;
+	   			index=it->first;
+	   		}
+	   		it++;
+		   }
+		   return std::make_pair(index,dist);
 		}
 	};
 

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -136,7 +136,15 @@ namespace nanoflann
 		}
 	};
 
-	struct IndexDist_Sorter;
+	/** operator "<" for std::sort() */
+	struct IndexDist_Sorter
+	{
+		/** PairType will be typically: std::pair<IndexType,DistanceType> */
+		template <typename PairType>
+		inline bool operator()(const PairType &p1, const PairType &p2) const {
+			return p1.second < p2.second;
+		}
+	};
 
 	/**
 	 * A result-set class used when performing a radius based search.
@@ -191,16 +199,7 @@ namespace nanoflann
 		}
 	};
 
-	/** operator "<" for std::sort() */
-	struct IndexDist_Sorter
-	{
-		/** PairType will be typically: std::pair<IndexType,DistanceType> */
-		template <typename PairType>
-		inline bool operator()(const PairType &p1, const PairType &p2) const {
-			return p1.second < p2.second;
-		}
-	};
-
+	
 	/** @} */
 
 

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -136,6 +136,7 @@ namespace nanoflann
 		}
 	};
 
+	struct IndexDist_Sorter;
 
 	/**
 	 * A result-set class used when performing a radius based search.
@@ -184,21 +185,9 @@ namespace nanoflann
 		std::pair<IndexType,DistanceType> worst_item() const
 		{
 		   if (m_indices_dists.empty()) throw std::runtime_error("Cannot invoke RadiusResultSet::worst_item() on an empty list of results.");
-		   typedef typename std::vector<std::pair<IndexType,DistanceType> >::iterator DistIt;
-		   DistIt it=m_indices_dists.begin();
-		   IndexType index=it->first;
-		   DistanceType dist=it->second;
-		   it++;
-		   while(it!=m_indices_dists.end())
-		   {
-	   		if(it->second>dist)
-	   		{
-	   			dist=it->second;
-	   			index=it->first;
-	   		}
-	   		it++;
-		   }
-		   return std::make_pair(index,dist);
+		   typedef typename std::vector<std::pair<IndexType,DistanceType> >::const_iterator DistIt;
+		   DistIt it = std::max_element(m_indices_dists.begin(), m_indices_dists.end(), IndexDist_Sorter());
+		   return *it;
 		}
 	};
 

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -762,7 +762,7 @@ namespace nanoflann
 
 		const KDTreeSingleIndexAdaptorParams index_params;
 
-		size_t m_size; //!< Number of current poins in the dataset
+		size_t m_size; //!< Number of current points in the dataset
 		size_t m_size_at_index_build; //!< Number of points in the dataset when the index was built
 		int dim;  //!< Dimensionality of each data point
 


### PR DESCRIPTION
In the current implementation of [worst_item](https://github.com/jlblancoc/nanoflann/blob/master/include/nanoflann.hpp#L184) module, to find the point at maximum distance from query point for a given radius, [std::max_element](https://github.com/jlblancoc/nanoflann/blob/master/include/nanoflann.hpp#L188) has been directly used on m_indices_dists. The problem is, [m_indices_dists](https://github.com/jlblancoc/nanoflann/blob/master/include/nanoflann.hpp#L149) is a vector of pair with first element being index and second element being distance. So when max_element is called it returns the maximum element with respect to index rather than the distance.