### PR TITLE
Prevent attempt to publish to GitHub Pages on PRs.

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -36,6 +36,11 @@ mkdir -p $OUT_DIR;
 
 doxygen
 
+# Only publish docs on merge to master
+if [ $TRAVIS_PULL_REQUEST ]; then
+  return
+fi
+
 cd $OUT_DIR
 git init
 


### PR DESCRIPTION
To prevent all PRs from failing the build docs job on Travis. Merge's to master will work the same.