### PR TITLE
KDTreeEigenMatrixAdaptor no longer requires DIM specification

### DIFF
--- a/examples/matrix_example.cpp
+++ b/examples/matrix_example.cpp
@@ -77,18 +77,18 @@ void kdtree_demo(const size_t nSamples,const size_t dim)
 	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic> >  my_kd_tree_t;
 
 	// Dimensionality set at compile-time
-//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic>, SAMPLES_DIM>  my_kd_tree_t;
+//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic> >  my_kd_tree_t;
 
 	// Dimensionality set at compile-time: Explicit selection of the distance metric: L2
-//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic>, SAMPLES_DIM,nanoflann::metric_L2>  my_kd_tree_t;
+//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic>,nanoflann::metric_L2>  my_kd_tree_t;
 
 	// Dimensionality set at compile-time: Explicit selection of the distance metric: L2_simple
-//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic>, SAMPLES_DIM,nanoflann::metric_L2_Simple>  my_kd_tree_t;
+//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic>,nanoflann::metric_L2_Simple>  my_kd_tree_t;
 
 	// Dimensionality set at compile-time: Explicit selection of the distance metric: L1
-//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic>, SAMPLES_DIM,nanoflann::metric_L1>  my_kd_tree_t;
+//	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic>,nanoflann::metric_L1>  my_kd_tree_t;
 
-	my_kd_tree_t   mat_index(dim /*dim*/, mat, 10 /* max leaf */ );
+	my_kd_tree_t   mat_index(mat, 10 /* max leaf */ );
 	mat_index.index->buildIndex();
 
 	// do a knn search

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1311,32 +1311,28 @@ namespace nanoflann
 	  *
 	  * 	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic> >  my_kd_tree_t;
 	  * 	const int max_leaf = 10;
-	  * 	my_kd_tree_t   mat_index(dimdim, mat, max_leaf );
+	  * 	my_kd_tree_t   mat_index(mat, max_leaf );
 	  * 	mat_index.index->buildIndex();
 	  * 	mat_index.index->...
 	  * \endcode
 	  *
-	  *  \tparam DIM If set to >0, it specifies a compile-time fixed dimensionality for the points in the data set, allowing more compiler optimizations.
 	  *  \tparam Distance The distance metric to use: nanoflann::metric_L1, nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
 	  */
-	template <class MatrixType, int DIM = -1, class Distance = nanoflann::metric_L2>
+	template <class MatrixType, class Distance = nanoflann::metric_L2>
 	struct KDTreeEigenMatrixAdaptor
 	{
-		typedef KDTreeEigenMatrixAdaptor<MatrixType,DIM,Distance> self_t;
+		typedef KDTreeEigenMatrixAdaptor<MatrixType,Distance> self_t;
 		typedef typename MatrixType::Scalar              num_t;
 		typedef typename MatrixType::Index IndexType;
 		typedef typename Distance::template traits<num_t,self_t>::distance_t metric_t;
-		typedef KDTreeSingleIndexAdaptor< metric_t,self_t,DIM,IndexType>  index_t;
+		typedef KDTreeSingleIndexAdaptor< metric_t,self_t, MatrixType::ColsAtCompileTime,IndexType>  index_t;
 
 		index_t* index; //! The kd-tree index for the user to call its methods as usual with any other FLANN index.
 
 		/// Constructor: takes a const ref to the matrix object with the data points
-		KDTreeEigenMatrixAdaptor(const int dimensionality, const MatrixType &mat, const int leaf_max_size = 10) : m_data_matrix(mat)
+		KDTreeEigenMatrixAdaptor(const MatrixType &mat, const int leaf_max_size = 10) : m_data_matrix(mat)
 		{
 			const IndexType dims = mat.cols();
-			if (dims!=dimensionality) throw std::runtime_error("Error: 'dimensionality' must match column count in data matrix");
-			if (DIM>0 && static_cast<int>(dims)!=DIM)
-				throw std::runtime_error("Data set dimensionality does not match the 'DIM' template argument");
 			index = new index_t( dims, *this /* adaptor */, nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size ) );
 			index->buildIndex();
 		}


### PR DESCRIPTION
It can be infered at compile time from the matrix type.

This one changes the API, but prevents the clients from having to insert the dimensionality in the first place.