### PR TITLE
Fixing submodule issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flann"]
+	   path = 3rdparty/flann
+	   url = git@github.com:mariusmuja/flann.git


### PR DESCRIPTION
Since the last [PR merge](https://github.com/jlblancoc/nanoflann/pull/48), it became impossible to clone recursively the project. Indeed, that would result in `fatal: No url found for submodule path '3rdparty/flann' in .gitmodules`
In order to fix that, I just added the missing `.gitmodules` file pointing to the repo and it seems that the issue is now gone. 