### PR TITLE
Refresh kdtree size before building the index

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1216,6 +1216,8 @@ namespace nanoflann
 		 */
 		void buildIndex()
 		{
+			BaseClassRef::m_size = dataset.kdtree_get_point_count();
+			BaseClassRef::m_size_at_index_build = BaseClassRef::m_size;
 			init_vind();
 			this->freeIndex(*this);
 			BaseClassRef::m_size_at_index_build = BaseClassRef::m_size;


### PR DESCRIPTION
Hi,

first of all, thank you so much for your software, it works great!

I had some problems keeping the instance KDTreeSingleIndexAdaptor around, mostly when the size of the points in the dataset change. This simple addition should make the code a little bit more "stupid proof" without any negative effect.

Cheers