### PR TITLE
Fix overload of log2

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1822,7 +1822,7 @@ namespace nanoflann
 			dataset(inputData), index_params(params), distance(inputData)
 		{
 			if (dataset.kdtree_get_point_count()) throw std::runtime_error("[nanoflann] cannot handle non empty point cloud.");
-			treeCount = log2(maximumPointCount);
+			treeCount = std::log2(maximumPointCount);
 			pointCount = 0U;
 			dim = dimensionality;
 			treeIndex.clear();


### PR DESCRIPTION
Hi,

I got these compilation errors with the current version in the master branch:
```
nanoflann.hpp(1825): error: more than one instance of overloaded function "log2" matches the argument list:
            function "log2(double)"
            function "log2(float)"
            argument types are: (const size_t)
```
The integral overloads of `log2` only exist in C++11 and not in C99 (see http://www.cplusplus.com/reference/cmath/log2/), thus triggering the error. This PR fixes the problem by using the C++ version of the function.

Best regards,
Patrick Stotko