### PR TITLE
Bug fix in KDTreeSingleIndexDynamicAdaptor

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1889,7 +1889,8 @@ public:
       for (int i = 0; i < pos; i++) {
         for (int j = 0; j < static_cast<int>(index[i].vind.size()); j++) {
           index[pos].vind.push_back(index[i].vind[j]);
-          treeIndex[index[i].vind[j]] = pos;
+          if (treeIndex[index[i].vind[j]] != -1)
+            treeIndex[index[i].vind[j]] = pos;
         }
         index[i].vind.clear();
         index[i].freeIndex(index[i]);


### PR DESCRIPTION
Problem:
When adding points within the KDTreeSingleIndexDynamicAdaptor class, the treeIndex of removed points gets overwritten with the index of the new tree. This results in previously deleted points being restored again.

To reproduce the problem:
* Add first point
* Remove the first point
* Add second point
* Search for first point (knnsearch)

Expected: second point gets returned
Outcome: first point gets returned

The proposed change would fix this by only overwriting those points whose treeIndex is not -1, d.h. the points which were not already removed.