### PR TITLE
Simplify CMakeLists for Eigen example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,21 +1,4 @@
-# Try to find Eigen3 for use in the examples
-FIND_PACKAGE(PkgConfig QUIET)
-MESSAGE(STATUS "Check for Eigen3")
-IF(PKG_CONFIG_FOUND)
-  PKG_CHECK_MODULES(PKG_EIGEN3 QUIET eigen3) # Try to find eigen3 with pkg-config
-ENDIF()
-SET(EIGEN3_FOUND FALSE)
-FIND_PATH(EIGEN3_INCLUDE NAMES signature_of_eigen3_matrix_library
-  PATHS ${CMAKE_INSTALL_PREFIX}/include ${PKG_EIGEN3_INCLUDE_DIRS}
-  PATH_SUFFIXES eigen3
-)
-IF (NOT EXISTS ${EIGEN3_INCLUDE})
-  MESSAGE(STATUS "Eigen3 not found in standard location. Try passing -DEIGEN3_INCLUDE=/path/to/eigen3")
-ELSE()
-  MESSAGE(STATUS "Using Eigen3 in: ${EIGEN3_INCLUDE}")
-  INCLUDE_DIRECTORIES("${EIGEN3_INCLUDE}")
-  SET(EIGEN3_FOUND TRUE)
-ENDIF()
+find_package(Eigen3)
 
 # examples:
 MACRO(DEFINE_EXAMPLE _NAME)
@@ -35,5 +18,6 @@ DEFINE_EXAMPLE(vector_of_vectors_example)
 
 IF(EIGEN3_FOUND)
 	DEFINE_EXAMPLE(matrix_example)
+    target_include_directories (matrix_example PRIVATE ${EIGEN3_INCLUDE_DIR})
 ENDIF()
 


### PR DESCRIPTION
Unnecessary CMakelists code removed. This only affects the project which use Eigen (matrix_example)