### PR TITLE
Avoid setting cmake global executable build path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ endif()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMakeTargets")
 
-set( EXECUTABLE_OUTPUT_PATH ${nanoflann_BINARY_DIR}/bin CACHE PATH "Output directory for programs" )
 add_definitions ( -DNANOFLANN_PATH="${CMAKE_SOURCE_DIR}" )
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,8 @@ MACRO(DEFINE_EXAMPLE _NAME)
 	ADD_EXECUTABLE(${_NAME} ${_NAME}.cpp)
 	set_target_properties(${_NAME} PROPERTIES FOLDER "Examples")
 	TARGET_LINK_LIBRARIES(${_NAME} nanoflann::nanoflann)  # adds the "#include" directory.
+  install(TARGETS ${_NAME}
+          DESTINATION examples)
 ENDMACRO()
 
 DEFINE_EXAMPLE(dynamic_pointcloud_example)


### PR DESCRIPTION
o This should be handled by the CMAKE_INSTALL_PREFIX definition, which
is user-defined.  Setting the global cmake leads to nasty side-effects
for other cmake projects that build nanoflann as a subdirectory.