### PR TITLE
Add optional argument for Eigen matrix layout

### DIFF
--- a/examples/matrix_example.cpp
+++ b/examples/matrix_example.cpp
@@ -96,6 +96,14 @@ void kdtree_demo(const size_t nSamples, const size_t dim) {
   //	typedef KDTreeEigenMatrixAdaptor<
   // Eigen::Matrix<num_t,Dynamic,Dynamic>,nanoflann::metric_L1>  my_kd_tree_t;
 
+  // Dimensionality set at compile-time: Explicit selection of the distance
+  // metric: L2
+  // Row Major matrix layout
+  // Eigen::Matrix<num_t, Dynamic, Dynamic> mat(dim, nSamples);
+  //	typedef KDTreeEigenMatrixAdaptor<
+  // Eigen::Matrix<num_t,Dynamic,Dynamic>,nanoflann::metric_L2, true>
+  // my_kd_tree_t;
+  
   my_kd_tree_t mat_index(dim, std::cref(mat), 10 /* max leaf */);
   mat_index.index->buildIndex();
 


### PR DESCRIPTION
Added an optional argument for the row/column layout of eigen matrices for the eigen adaptor.
Basically to fulfil this issue #37 as I want that functionality too.