### PR TITLE
Install nanoflann architecture-independently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------------
 # Root CMake file for nanoflann
 # ----------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.1)
 
 # Extract library version into "NANOFLANN_VERSION"
 # -----------------------------------------------------
@@ -125,12 +125,19 @@ configure_package_config_file(
     INSTALL_DESTINATION ${INSTALL_CMAKE_DIR}
     PATH_VARS INSTALL_INCLUDE_DIR)
 
+# Setting CMAKE_SIZEOF_VOID_P to the empty string has the same
+# effect as the ARCH_INDEPENDENT option of
+# write_basic_package_version_file(), but works with older CMake
+# versions before 3.14
+set(backup_of_CMAKE_SIZEOF_VOID_P "${CMAKE_SIZEOF_VOID_P}")
+set(CMAKE_SIZEOF_VOID_P "")
+
 write_basic_package_version_file(
     "${nanoflann_BINARY_DIR}/nanoflannConfigVersion.cmake"
     VERSION ${nanoflann_VERSION}
-    ARCH_INDEPENDENT
     COMPATIBILITY AnyNewerVersion)
 
+set(CMAKE_SIZEOF_VOID_P "${backup_of_CMAKE_SIZEOF_VOID_P}")
 
 # Uninstall target, for "make uninstall"
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------------
 # Root CMake file for nanoflann
 # ----------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.14)
 
 # Extract library version into "NANOFLANN_VERSION"
 # -----------------------------------------------------
@@ -49,7 +49,7 @@ add_definitions ( -DNANOFLANN_PATH="${CMAKE_SOURCE_DIR}" )
 
 # Set relative install directories
 set(INSTALL_INCLUDE_DIR "include")
-set(INSTALL_PKGCONFIG_DIR "lib${LIB_SUFFIX}/pkgconfig")
+set(INSTALL_PKGCONFIG_DIR "share/pkgconfig")
 set(INSTALL_CMAKE_DIR "lib${LIB_SUFFIX}/cmake/nanoflann")
 set(INSTALL_COPYRIGHT_DIR "share/doc/libnanoflann-dev")
 
@@ -128,6 +128,7 @@ configure_package_config_file(
 write_basic_package_version_file(
     "${nanoflann_BINARY_DIR}/nanoflannConfigVersion.cmake"
     VERSION ${nanoflann_VERSION}
+    ARCH_INDEPENDENT
     COMPATIBILITY AnyNewerVersion)
 
 


### PR DESCRIPTION
This PR installs the nanoflann.pc to /usr/share/pkgconfig, where it will
be found for all architectures, and adds the ARCH_INDEPENDENT option to
write_basic_package_version_file().

The latter requires at least CMake 3.14 to work. If this is not
acceptable for some reason, I can rewrite this with a known workaround
to set CMAKE_SIZE_OF_VOID_P to "" temporarily.