### PR TITLE
Use target compile features instead of CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,6 @@ project(nanoflann VERSION "${NANOFLANN_VERSION_MAJOR}.${NANOFLANN_VERSION_MINOR}
 message(STATUS "nanoflann version: ${NANOFLANN_VERSION_MAJOR}.${NANOFLANN_VERSION_MINOR}.${NANOFLANN_VERSION_PATCH}")
 file(WRITE "${nanoflann_BINARY_DIR}/version" "${NANOFLANN_VERSION_MAJOR}.${NANOFLANN_VERSION_MINOR}.${NANOFLANN_VERSION_PATCH}")
 
-
-# Compiler options:
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Enable a high level of warnings.
 if (CMAKE_COMPILER_IS_GNUCXX)
 	# The -Wno-long-long is required in 64bit systems when including sytem headers.
@@ -58,6 +53,13 @@ set(INSTALL_COPYRIGHT_DIR "${CMAKE_INSTALL_DOCDIR}")
 # Define nanoflann lib (header-only)
 add_library(nanoflann INTERFACE)
 
+# Tell CMake which C++ features we need
+target_compile_features(nanoflann
+	INTERFACE
+		cxx_auto_type
+		cxx_decltype
+		cxx_deleted_functions
+)
 target_include_directories(nanoflann
 	INTERFACE
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
This is a very nice feature of CMake that was added in version 3.1.

Instead of forcing C++11 with CXX_STANDARD, which might actually
*downgrade* the compiler from a newer standard, we just tell CMake which
C++ features we need, and CMake will automatically choose the proper
standard (or complain if the compiler does not support it).

Additionally, I added the feature list as a target property, so it will
be put in the installed CMake config script and propagate to library
users. This way, CMake will automatically ensure that any project that
includes nanoflann is compiled with at least C++11.

For reference, the CMake 3.1 manual has a [list of known C++ features](https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html#prop_gbl:CMAKE_CXX_KNOWN_FEATURES).