### PR TITLE
KDTreeEigenMatrixAdaptor unconditionally sets dimensions KDTreeSingleIndexAdaptor to MatrixType::ColsAtCompileTime, which is only correct for row major ordering

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1960,7 +1960,7 @@ struct KDTreeEigenMatrixAdaptor {
   typedef
       typename Distance::template traits<num_t, self_t>::distance_t metric_t;
   typedef KDTreeSingleIndexAdaptor<metric_t, self_t,
-                                   MatrixType::ColsAtCompileTime, IndexType>
+  	row_major ? MatrixType::ColsAtCompileTime : MatrixType::RowsAtCompileTime, IndexType>
       index_t;
 
   index_t *index; //! The kd-tree index for the user to call its methods as


### PR DESCRIPTION
Corrected bug where the number of dimensions in the KDTreeSingleIndexAdaptor was unconditionally set to the number of columns, which means it assumed row major ordering.