### PR TITLE
Switch to C++ streams for index saving and loading

### DIFF
--- a/examples/saveload_example.cpp
+++ b/examples/saveload_example.cpp
@@ -31,6 +31,7 @@
 
 #include <ctime>
 #include <cstdlib>
+#include <fstream>
 #include <iostream>
 
 using namespace std;
@@ -60,10 +61,9 @@ void kdtree_save_load_demo(const size_t N)
 		my_kd_tree_t   index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10 /* max leaf */) );
 		index.buildIndex();
 
-		FILE *f = fopen("index.bin", "wb");
-		if (!f) throw std::runtime_error("Error writing index file!");
+		ofstream f("index.bin"); //, "wb"
 		index.saveIndex(f);
-		fclose(f);
+		f.close();
 	}
 
 
@@ -73,10 +73,9 @@ void kdtree_save_load_demo(const size_t N)
 		// Important: construct the index associated to the same dataset, since data points are NOT stored in the binary file.
 		my_kd_tree_t   index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10 /* max leaf */) );
 
-		FILE *f = fopen("index.bin", "rb");
-		if (!f) throw std::runtime_error("Error reading index file!");
+		ifstream f("index.bin"); //, "rb"
 		index.loadIndex(f);
-		fclose(f);
+		f.close();
 
 		// do a knn search
 		const size_t num_results = 1;

--- a/examples/saveload_example.cpp
+++ b/examples/saveload_example.cpp
@@ -61,7 +61,11 @@ void kdtree_save_load_demo(const size_t N)
 		my_kd_tree_t   index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10 /* max leaf */) );
 		index.buildIndex();
 
-		ofstream f("index.bin"); //, "wb"
+		ofstream f("index.bin", std::ofstream::binary);
+
+		if(f.bad())
+		  throw std::runtime_error("Error writing index file!");
+
 		index.saveIndex(f);
 		f.close();
 	}
@@ -73,7 +77,11 @@ void kdtree_save_load_demo(const size_t N)
 		// Important: construct the index associated to the same dataset, since data points are NOT stored in the binary file.
 		my_kd_tree_t   index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10 /* max leaf */) );
 
-		ifstream f("index.bin"); //, "rb"
+		ifstream f("index.bin", std::ofstream::binary);
+
+		if(f.fail())
+		  throw std::runtime_error("Error reading index file!");
+
 		index.loadIndex(f);
 		f.close();
 

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -51,10 +51,11 @@
 #include <array>
 #include <cassert>
 #include <cmath>   // for abs()
-#include <cstdio>  // for fwrite()
 #include <cstdlib> // for abs()
 #include <functional>
+#include <istream>
 #include <limits> // std::reference_wrapper
+#include <ostream>
 #include <stdexcept>
 #include <vector>
 
@@ -275,25 +276,25 @@ public:
 
 /** @addtogroup loadsave_grp Load/save auxiliary functions
  * @{ */
-template <typename Stream, typename T>
-void save_value(Stream &stream, const T &value) {
+template <typename T>
+void save_value(std::ostream &stream, const T &value) {
   stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
 }
 
-template <typename Stream, typename T>
-void save_value(Stream& stream, const std::vector<T> &value) {
+template <typename T>
+void save_value(std::ostream& stream, const std::vector<T> &value) {
   size_t size = value.size();
   stream.write(reinterpret_cast<const char*>(&size), sizeof(size_t));
   stream.write(reinterpret_cast<const char*>(value.data()), sizeof(T) * size);
 }
 
-template <typename Stream, typename T>
-void load_value(Stream& stream, T &value) {
+template <typename T>
+void load_value(std::istream& stream, T &value) {
   stream.read(reinterpret_cast<char*>(&value), sizeof(T));
 }
 
-template <typename Stream, typename T>
-void load_value(Stream &stream, std::vector<T> &value) {
+template <typename T>
+void load_value(std::istream &stream, std::vector<T> &value) {
   size_t size;
   stream.read(reinterpret_cast<char*>(&size), sizeof(size_t));
   value.resize(size);
@@ -1013,8 +1014,7 @@ public:
     return distsq;
   }
 
-  template<typename Stream>
-  void save_tree(Derived &obj, Stream &stream, NodePtr tree) {
+  void save_tree(Derived &obj, std::ostream &stream, NodePtr tree) {
     save_value(stream, *tree);
     if (tree->child1 != NULL) {
       save_tree(obj, stream, tree->child1);
@@ -1024,8 +1024,7 @@ public:
     }
   }
 
-  template<typename Stream>
-  void load_tree(Derived &obj, Stream &stream, NodePtr &tree) {
+  void load_tree(Derived &obj, std::istream &stream, NodePtr &tree) {
     tree = obj.pool.template allocate<Node>();
     load_value(stream, *tree);
     if (tree->child1 != NULL) {
@@ -1041,8 +1040,7 @@ public:
    * loading the index object it must be constructed associated to the same
    * source of data points used while building it. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  template<typename Stream>
-  void saveIndex_(Derived &obj, Stream& stream) {
+  void saveIndex_(Derived &obj, std::ostream &stream) {
     save_value(stream, obj.m_size);
     save_value(stream, obj.dim);
     save_value(stream, obj.root_bbox);
@@ -1056,8 +1054,7 @@ public:
    * index object must be constructed associated to the same source of data
    * points used while building the index. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  template<typename Stream>
-  void loadIndex_(Derived &obj, Stream &stream) {
+  void loadIndex_(Derived &obj, std::istream &stream) {
     load_value(stream, obj.m_size);
     load_value(stream, obj.dim);
     load_value(stream, obj.root_bbox);
@@ -1410,16 +1407,14 @@ public:
    * loading the index object it must be constructed associated to the same
    * source of data points used while building it. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  template<typename Stream>
-  void saveIndex(Stream& stream) { this->saveIndex_(*this, stream); }
+  void saveIndex(std::ostream &stream) { this->saveIndex_(*this, stream); }
 
   /**  Loads a previous index from a binary file.
    *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the
    * index object must be constructed associated to the same source of data
    * points used while building the index. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  template<typename Stream>
-  void loadIndex(Stream& stream) { this->loadIndex_(*this, stream); }
+  void loadIndex(std::istream &stream) { this->loadIndex_(*this, stream); }
 
 }; // class KDTree
 
@@ -1756,16 +1751,14 @@ public:
    * loading the index object it must be constructed associated to the same
    * source of data points used while building it. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  template<typename Stream>
-  void saveIndex(Stream &stream) { this->saveIndex_(*this, stream); }
+  void saveIndex(std::ostream &stream) { this->saveIndex_(*this, stream); }
 
   /**  Loads a previous index from a binary file.
    *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the
    * index object must be constructed associated to the same source of data
    * points used while building the index. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  template<typename Stream>
-  void loadIndex(Stream &stream) { this->loadIndex_(*this, stream); }
+  void loadIndex(std::istream &stream) { this->loadIndex_(*this, stream); }
 };
 
 /** kd-tree dynaimic index

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -275,37 +275,29 @@ public:
 
 /** @addtogroup loadsave_grp Load/save auxiliary functions
  * @{ */
-template <typename T>
-void save_value(FILE *stream, const T &value, size_t count = 1) {
-  fwrite(&value, sizeof(value), count, stream);
+template <typename Stream, typename T>
+void save_value(Stream &stream, const T &value) {
+  stream.write(reinterpret_cast<const char*>(&value), sizeof(T));
 }
 
-template <typename T>
-void save_value(FILE *stream, const std::vector<T> &value) {
+template <typename Stream, typename T>
+void save_value(Stream& stream, const std::vector<T> &value) {
   size_t size = value.size();
-  fwrite(&size, sizeof(size_t), 1, stream);
-  fwrite(&value[0], sizeof(T), size, stream);
+  stream.write(reinterpret_cast<const char*>(&size), sizeof(size_t));
+  stream.write(reinterpret_cast<const char*>(value.data()), sizeof(T) * size);
 }
 
-template <typename T>
-void load_value(FILE *stream, T &value, size_t count = 1) {
-  size_t read_cnt = fread(&value, sizeof(value), count, stream);
-  if (read_cnt != count) {
-    throw std::runtime_error("Cannot read from file");
-  }
+template <typename Stream, typename T>
+void load_value(Stream& stream, T &value) {
+  stream.read(reinterpret_cast<char*>(&value), sizeof(T));
 }
 
-template <typename T> void load_value(FILE *stream, std::vector<T> &value) {
+template <typename Stream, typename T>
+void load_value(Stream &stream, std::vector<T> &value) {
   size_t size;
-  size_t read_cnt = fread(&size, sizeof(size_t), 1, stream);
-  if (read_cnt != 1) {
-    throw std::runtime_error("Cannot read from file");
-  }
+  stream.read(reinterpret_cast<char*>(&size), sizeof(size_t));
   value.resize(size);
-  read_cnt = fread(&value[0], sizeof(T), size, stream);
-  if (read_cnt != size) {
-    throw std::runtime_error("Cannot read from file");
-  }
+  stream.read(reinterpret_cast<char*>(value.data()), sizeof(T) * size);
 }
 /** @} */
 
@@ -1021,7 +1013,8 @@ public:
     return distsq;
   }
 
-  void save_tree(Derived &obj, FILE *stream, NodePtr tree) {
+  template<typename Stream>
+  void save_tree(Derived &obj, Stream &stream, NodePtr tree) {
     save_value(stream, *tree);
     if (tree->child1 != NULL) {
       save_tree(obj, stream, tree->child1);
@@ -1031,7 +1024,8 @@ public:
     }
   }
 
-  void load_tree(Derived &obj, FILE *stream, NodePtr &tree) {
+  template<typename Stream>
+  void load_tree(Derived &obj, Stream &stream, NodePtr &tree) {
     tree = obj.pool.template allocate<Node>();
     load_value(stream, *tree);
     if (tree->child1 != NULL) {
@@ -1047,7 +1041,8 @@ public:
    * loading the index object it must be constructed associated to the same
    * source of data points used while building it. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  void saveIndex_(Derived &obj, FILE *stream) {
+  template<typename Stream>
+  void saveIndex_(Derived &obj, Stream& stream) {
     save_value(stream, obj.m_size);
     save_value(stream, obj.dim);
     save_value(stream, obj.root_bbox);
@@ -1061,7 +1056,8 @@ public:
    * index object must be constructed associated to the same source of data
    * points used while building the index. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  void loadIndex_(Derived &obj, FILE *stream) {
+  template<typename Stream>
+  void loadIndex_(Derived &obj, Stream &stream) {
     load_value(stream, obj.m_size);
     load_value(stream, obj.dim);
     load_value(stream, obj.root_bbox);
@@ -1414,14 +1410,16 @@ public:
    * loading the index object it must be constructed associated to the same
    * source of data points used while building it. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  void saveIndex(FILE *stream) { this->saveIndex_(*this, stream); }
+  template<typename Stream>
+  void saveIndex(Stream& stream) { this->saveIndex_(*this, stream); }
 
   /**  Loads a previous index from a binary file.
    *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the
    * index object must be constructed associated to the same source of data
    * points used while building the index. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  void loadIndex(FILE *stream) { this->loadIndex_(*this, stream); }
+  template<typename Stream>
+  void loadIndex(Stream& stream) { this->loadIndex_(*this, stream); }
 
 }; // class KDTree
 
@@ -1758,14 +1756,16 @@ public:
    * loading the index object it must be constructed associated to the same
    * source of data points used while building it. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  void saveIndex(FILE *stream) { this->saveIndex_(*this, stream); }
+  template<typename Stream>
+  void saveIndex(Stream &stream) { this->saveIndex_(*this, stream); }
 
   /**  Loads a previous index from a binary file.
    *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the
    * index object must be constructed associated to the same source of data
    * points used while building the index. See the example:
    * examples/saveload_example.cpp \sa loadIndex  */
-  void loadIndex(FILE *stream) { this->loadIndex_(*this, stream); }
+  template<typename Stream>
+  void loadIndex(Stream &stream) { this->loadIndex_(*this, stream); }
 };
 
 /** kd-tree dynaimic index


### PR DESCRIPTION
This PR introduces C++ streams instead of the C file handles used before. The intent here is to make the library more consistent w.r.t. its programming language usage and enable specific use cases that are hard to realize portably with C file handles (e.g. in-memory streams).

Some comments in response to @jlblancoc s comments in #156:

* Using `<iosfwd>` did not work out, as it only contains forward declarations of the stream classes, so we cannot use stream methods like `read` and `write` directly in the header. My compiler only produced warnings for this, but they are rather annoying. Instead, I had to include `<istream>` + `<ostream>`.
* The Doxygen annotations already state that we save in binary format. Nothing changed about that.

This fixes #156.