### PR TITLE
fix-142: updating index of tree in which point is stored

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -54,6 +54,7 @@
 #include <limits>  // std::reference_wrapper
 #include <ostream>
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 /** Library version: 0xMmP (M=Major,m=minor,P=patch) */
@@ -2089,6 +2090,7 @@ class KDTreeSingleIndexDynamicAdaptor
         treeIndex;  //!< treeIndex[idx] is the index of tree in which
                     //!< point at idx is stored. treeIndex[idx]=-1
                     //!< means that point has been removed.
+    std::unordered_set<int> removedPoints;
 
     KDTreeSingleIndexAdaptorParams index_params;
 
@@ -2180,6 +2182,14 @@ class KDTreeSingleIndexDynamicAdaptor
             int pos = First0Bit(pointCount);
             index[pos].vAcc.clear();
             treeIndex[pointCount] = pos;
+
+            const auto it = removedPoints.find(idx);
+            if(it != removedPoints.end())
+            {
+                removedPoints.erase(it);
+                treeIndex[idx] = pos;
+            }
+
             for (int i = 0; i < pos; i++)
             {
                 for (int j = 0; j < static_cast<int>(index[i].vAcc.size()); j++)
@@ -2201,6 +2211,7 @@ class KDTreeSingleIndexDynamicAdaptor
     void removePoint(size_t idx)
     {
         if (idx >= pointCount) return;
+        removedPoints.insert(idx);
         treeIndex[idx] = -1;
     }
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -504,3 +504,45 @@ TEST(kdtree,robust_nonempty_tree)
 		nanoflann::SearchParams(10));
 	EXPECT_EQ(result, true);
 }
+
+TEST(kdtree, add_and_remove_points) {
+	PointCloud<double> cloud;
+	cloud.pts = {{0.0, 0.0, 0.0}, {0.5, 0.5, 0.5}, {0.7, 0.7, 0.7}};
+
+	typedef KDTreeSingleIndexDynamicAdaptor<
+		L2_Simple_Adaptor<double, PointCloud<double> > ,
+		PointCloud<double>,
+		3
+		> my_kd_tree_simple_t;
+
+	my_kd_tree_simple_t index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10 /* max leaf */));
+
+	const auto query = [&index]() -> size_t {
+		const double query_pt[3] = {0.5, 0.5, 0.5};
+		const size_t num_results = 1;
+		std::vector<size_t> ret_index(num_results);
+		std::vector<double> out_dist_sqr(num_results);
+		nanoflann::KNNResultSet<double> resultSet(num_results);
+
+		resultSet.init(&ret_index[0], &out_dist_sqr[0]);
+		index.findNeighbors(resultSet, &query_pt[0], nanoflann::SearchParams(10));
+
+		return ret_index[0];
+	};
+
+	auto actual = query();
+	EXPECT_EQ(actual, static_cast<size_t>(1));
+
+	index.removePoint(1);
+	actual = query();
+	EXPECT_EQ(actual, static_cast<size_t>(2));
+
+	index.addPoints(1, 1);
+	actual = query();
+	EXPECT_EQ(actual, static_cast<size_t>(1));
+
+	index.removePoint(1);
+	index.removePoint(2);
+	actual = query();
+	EXPECT_EQ(actual, static_cast<size_t>(0));
+}


### PR DESCRIPTION
Index of tree in which point is stored was not being updated when a removed point was re-added to a KDTreeSingleIndexDynamicAdaptor.