### PR TITLE
fix-167: make project compile with gcc versions <= 4.8.5 and clang versions <= 10.0.1

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1352,7 +1352,7 @@ class KDTreeSingleIndexAdaptor
     template <class... Args>
     KDTreeSingleIndexAdaptor(
         const Dimension dimensionality, const DatasetAdaptor& inputData,
-        const KDTreeSingleIndexAdaptorParams& params = {}, Args&&... args)
+        const KDTreeSingleIndexAdaptorParams& params, Args&&... args)
         : dataset(inputData),
           index_params(params),
           distance(inputData, std::forward<Args>(args)...)
@@ -1368,6 +1368,12 @@ class KDTreeSingleIndexAdaptor
             buildIndex();
         }
     }
+
+    template <class... Args>
+    KDTreeSingleIndexAdaptor(
+        const Dimension dimensionality, const DatasetAdaptor& inputData, Args&&... args)
+        : KDTreeSingleIndexAdaptorParams(dimensionality, inputData, {}, std::forward<Args>(args)...)
+    {}
 
     /**
      * Builds the index


### PR DESCRIPTION
gcc <= 4.8.5 and clang <= 10.0.1 do not accept function parameter packs after a
parameter with default argument, which is perfectly valid C++ code according to
standard (8.3.6 ([dcl.fct.default])/4)

Here we remove the default and overload ctr to bypass limitation in those versions