### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ add_executable(my_project test.cpp)
 target_link_libraries(my_project nanoflann::nanoflann)
 ```
 
+### 1.8. Package Managers
+
+You can download and install nanoflann using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install nanoflann
+
+The nanoflann port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ------
 
 ## 2. Any help choosing the KD-tree parameters?


### PR DESCRIPTION
`nanoflann `is available as a port in vcpkg, a C++ library manager that simplifies installation for `nanoflann `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build nanoflann, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/nanoflann/portfile.cmake). We try to keep the library maintained as close as possible to the original library.