### PR TITLE
examples: Use resultSet.size() in result printing loop instead of num_results

### DIFF
--- a/examples/matrix_example.cpp
+++ b/examples/matrix_example.cpp
@@ -110,7 +110,7 @@ void kdtree_demo(const size_t nSamples, const size_t dim)
     mat_index.index_->findNeighbors(resultSet, &query_pt[0]);
 
     std::cout << "knnSearch(nn=" << num_results << "): \n";
-    for (size_t i = 0; i < num_results; i++)
+    for (size_t i = 0; i < resultSet.size(); i++)
         std::cout << "ret_index[" << i << "]=" << ret_indexes[i]
                   << " out_dist_sqr=" << out_dists_sqr[i] << std::endl;
 }

--- a/examples/vector_of_vectors_example.cpp
+++ b/examples/vector_of_vectors_example.cpp
@@ -87,7 +87,7 @@ void kdtree_demo(const size_t nSamples, const size_t dim)
     mat_index.index->findNeighbors(resultSet, &query_pt[0]);
 
     std::cout << "knnSearch(nn=" << num_results << "): \n";
-    for (size_t i = 0; i < num_results; i++)
+    for (size_t i = 0; i < resultSet.size(); i++)
         std::cout << "ret_index[" << i << "]=" << ret_indexes[i]
                   << " out_dist_sqr=" << out_dists_sqr[i] << std::endl;
 }


### PR DESCRIPTION
In some examples the original variable num_results is used for printing the nearest neighbor search results. Wouldn't it be more correct to use resultSet.size() instead?