### PR TITLE
fix warning -Wzero-as-null-pointer-constant

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -174,7 +174,7 @@ class KNNResultSet
 
    public:
     explicit KNNResultSet(CountType capacity_)
-        : indices(0), dists(0), capacity(capacity_), count(0)
+        : indices(nullptr), dists(nullptr), capacity(capacity_), count(0)
     {
     }
 


### PR DESCRIPTION
Hi, this PR contains a minor fix for the following warning:
```
nanoflann.hpp:177:19: warning: zero as null pointer constant [-Wzero-as-null-pointer-constant]
        : indices(0), dists(0), capacity(capacity_), count(0)
                  ^
                  nullptr
```