### PR TITLE
Current LinuxBrew links to a suspicious site

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Cite as:
   ```
   $ sudo port install nanoflann
   ```
-* Linux users can also install it with [Linuxbrew](https://linuxbrew.sh/) with: `brew install homebrew/science/nanoflann`
+* Linux users can also install it with [Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux) with: `brew install homebrew/science/nanoflann`
 * List of [**stable releases**](https://github.com/jlblancoc/nanoflann/releases). Check out the [CHANGELOG](https://github.com/jlblancoc/nanoflann/blob/master/CHANGELOG.md)
 
 Although nanoflann itself doesn't have to be compiled, you can build some examples and tests with:


### PR DESCRIPTION
Current LinuxBrew links to a suspicious site, setting https://docs.brew.sh/Homebrew-on-Linux instead