### PR TITLE
Add concurrent tree build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ nanoflann 1.5.0: UNRELEASED
      ctor parameters.
    - Added method RadiusResultSet::empty()
    - Template argument rename: `AccesorType` => `IndexType` (does not actually affect user code at all).
+   - Added concurrent tree building support, refer to `KDTreeSingleIndexAdaptorParams::n_thread_build`.
  * **Other changes:**
    - Macros to avoid conflicts with X11 symbols.
    - Inline an auxiliary example function in case users want to use it and

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ So, it seems that a `leaf_max_size` **between 10 and 50** would be optimum in ap
 
 This parameter is really ignored in `nanoflann`, but was kept for backward compatibility with the original FLANN interface. Just ignore it.
 
+### 2.3. `KDTreeSingleIndexAdaptorParams::n_thread_build`
+
+This parameter determines the maximum number of threads that can be called concurrently during the construction of the KD tree. The default value is 1. When the parameter is set to 0, `nanoflann` automatically determines the number of threads to use.
+
 -----
 
 ## 3. Performance

--- a/examples/KDTreeVectorOfVectorsAdaptor.h
+++ b/examples/KDTreeVectorOfVectorsAdaptor.h
@@ -69,7 +69,7 @@ struct KDTreeVectorOfVectorsAdaptor
     /// data points
     KDTreeVectorOfVectorsAdaptor(
         const size_t /* dimensionality */, const VectorOfVectorsType& mat,
-        const int leaf_max_size = 10)
+        const int leaf_max_size = 10, const unsigned int n_thread_build = 1)
         : m_data(mat)
     {
         assert(mat.size() != 0 && mat[0].size() != 0);
@@ -80,7 +80,7 @@ struct KDTreeVectorOfVectorsAdaptor
                 "argument");
         index = new index_t(
             static_cast<int>(dims), *this /* adaptor */,
-            nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size));
+            nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size, KDTreeSingleIndexAdaptorFlags::None, n_thread_build));
     }
 
     ~KDTreeVectorOfVectorsAdaptor() { delete index; }


### PR DESCRIPTION
### Related issue

#165 

### Problem with helgrind
When tested with valgrind --tool=helgrind tests/unit_tests, the output is like:
```
==551969== Possible data race during write of size 8 at 0x4DF8E48 by thread #4
==551969== Locks held: none
==551969==    at 0x4858B70: memset (in /usr/libexec/valgrind/vgpreload_helgrind-amd64-linux.so)
==551969==    by 0x4C49017: get_cached_stack (allocatestack.c:138)
==551969==    by 0x4C49017: allocate_stack (allocatestack.c:364)
==551969==    by 0x4C49017: pthread_create@@GLIBC_2.34 (pthread_create.c:647)
...
```
Then I checked [source code of glibc](https://github.com/bminor/glibc/blob/glibc-2.34/nptl/allocatestack.c#L136), and get
```cpp
memset (dtv, '\0', (dtv[-1].counter + 1) * sizeof (dtv_t));
```
at the line mentioned in helgrind. This line of code belongs to the function used to create threads in GLIBC's nptl module, so it looks like helgrind detected it during a concurrent call to std::async. In my test, the warning can be supressed by locking the std::async like:
```cpp
lock.lock();
left_future = std::async(...);
lock.unlock();
```
You can also reproduce the problem with helgrind from the following code:
```cpp
    auto create_threads = []()
    {
        std::future<void> future[10];
        for(int t = 0; t < 10; ++t){
            future[t] = std::async(std::launch::async, [](){ int i = 0; ++i; });
        }
        for(int t = 0; t < 10; ++t){
            future[t].get();
        }
    };
    auto future1 = std::async(std::launch::async, create_threads);
    auto future2 = std::async(std::launch::async, create_threads);
    future1.get();
    future2.get();
```
So yes, the warning of helgrind is false positive, helgrind just warns when you create threads concurrently with glibc.

### Performance

The performance improvement depends on the number of threads. In my tests, concurrent builds with 8-16 threads can improve building performance by up to around 3x.