### PR TITLE
fix: thread_count failed to construct before g++11

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1556,7 +1556,7 @@ class KDTreeSingleIndexAdaptor
         }
         else
         {
-            std::atomic<unsigned int> thread_count = 0;
+            std::atomic<unsigned int> thread_count(0u);
             std::mutex                mutex;
             Base::root_node_ = this->divideTreeConcurrent(
                 *this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);
@@ -1992,7 +1992,7 @@ class KDTreeSingleIndexDynamicAdaptor_
         }
         else
         {
-            std::atomic<unsigned int> thread_count = 0;
+            std::atomic<unsigned int> thread_count(0u);
             std::mutex                mutex;
             Base::root_node_ = this->divideTreeConcurrent(
                 *this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);


### PR DESCRIPTION
[PR 198](https://github.com/jlblancoc/nanoflann/pull/198) fails to build with g++ 9 since 
`std::atomic<unsigned int> thread_count = 0;` 
would call deleted copy constructor 
`atomic& operator=(const atomic&) = delete;` 
instead of `constexpr atomic(__integral_type __i) noexcept : __base_type(__i) { }` before g++ 11 and clang 16.
This new construction method is to use `std::atomic<unsigned int> thread_count(0u);`, which will successfully compile in my tests with g++ 4.8.5, 9, 10, 11, and 12.