### PR TITLE
Look for Threads dependency in CMake config script

### DIFF
--- a/scripts/nanoflannConfig.cmake.in
+++ b/scripts/nanoflannConfig.cmake.in
@@ -1,5 +1,8 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/nanoflannTargets.cmake")
 
 # (JLBC Feb 2021: Not used anymore?)


### PR DESCRIPTION
This is a fix for Debian bug [#1058950](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1058950). Unfortunately, both the autopkgtest  (via GTest) and my own use already have a `find_package(Threads)`, so this bug never triggered for me.
