### PR TITLE
c++20 and cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,9 @@ configure_file(
   "${nanoflann_BINARY_DIR}/cmake_uninstall.cmake"
   @ONLY IMMEDIATE)
 
-if ( 0 ) #NOT TARGET uninstall)
+option(MASTER_PROJECT_HAS_TARGET_UNINSTALL "uninstall target to master project CMakeLists.txt" OFF)
+
+if(NOT MASTER_PROJECT_HAS_TARGET_UNINSTALL OR NOT TARGET uninstall)
   add_custom_target(uninstall
     "${CMAKE_COMMAND}" -P "${nanoflann_BINARY_DIR}/cmake_uninstall.cmake")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,16 @@ if(NOT DEFINED PKGCONFIG_INSTALL_DIR)
   set(PKGCONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
-# Save all executables (unit tests & examples) in the same place:
-set(EXECUTABLE_OUTPUT_PATH ${${PROJECT_NAME}_BINARY_DIR}/bin CACHE PATH "Output directory for executables")
+if (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_SOURCE_DIR})
+	# This is the root project
+	set(MASTER_PROJECT ON)
+else()
+	set(MASTER_PROJECT OFF)
+endif()
+if (MASTER_PROJECT)
+	# Save all executables (unit tests & examples) in the same place:
+	set(EXECUTABLE_OUTPUT_PATH ${${PROJECT_NAME}_BINARY_DIR}/bin CACHE PATH "Output directory for executables")
+endif()
 
 # Define nanoflann lib (header-only)
 add_library(nanoflann INTERFACE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ configure_file(
   "${nanoflann_BINARY_DIR}/cmake_uninstall.cmake"
   @ONLY IMMEDIATE)
 
-if (NOT TARGET uninstall)
+if ( 0 ) #NOT TARGET uninstall)
   add_custom_target(uninstall
     "${CMAKE_COMMAND}" -P "${nanoflann_BINARY_DIR}/cmake_uninstall.cmake")
 else()

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -49,6 +49,7 @@
 #include <cassert>
 #include <cmath>  // for abs()
 #include <cstdlib>  // for abs()
+#include <cstdint>
 #include <functional>  // std::reference_wrapper
 #include <istream>
 #include <limits>  // std::numeric_limits


### PR DESCRIPTION
Dear nanoflann devs

here are two small fixes for 
- disable uninstall target is nanoflann is included in a master project
- fix compilation in c++20, cstdint needs to be included