### PR TITLE
fix bug that the min and max elem in middleSplit_ is wrong sometimes.

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1300,6 +1300,10 @@ class KDTreeBaseClass
         ElementType max_spread = -1;
         cutfeat                = 0;
         ElementType min_elem = 0, max_elem = 0;
+
+        if (max_span == 0)
+            computeMinMax(obj, ind, count, cutfeat, min_elem, max_elem);
+                
         for (Dimension i = 0; i < dims; ++i)
         {
             ElementType span = bbox[i].high - bbox[i].low;


### PR DESCRIPTION


if  span is always equal to max_span and equal to 0,if condition(span > (1 - EPS) * max_span) is always false, the  min_elem and max_elem are always the default initailized value 0, this is a bug. so the max_elem and min_elem should inlitialized while setting max_span.
This bug could be occur while there all the points which has the same location(x,y,z).