### PR TITLE
Add ifdef to disable pthreads usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ You can download and install nanoflann using the [vcpkg](https://github.com/Micr
 
 The nanoflann port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+
+### 1.9. Compile time definitions
+
+  * `NANOFLANN_FIRST_MATCH`: If defined and two points have the same distance, the one with the lowest-index will be returned first. Otherwise there is no particular order.
+  * `NANOFLANN_NO_THREADS`: If defined, multithreading capabilities will be disabled, so that the library can be used without linking with pthreads. If one tries to use multiple threads, an exception will be thrown.
+
 ------
 
 ## 2. Any help choosing the KD-tree parameters?

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1627,10 +1627,14 @@ class KDTreeSingleIndexAdaptor
         }
         else
         {
+#ifndef NANOFLANN_NO_THREADS
             std::atomic<unsigned int> thread_count(0u);
             std::mutex                mutex;
             Base::root_node_ = this->divideTreeConcurrent(
                 *this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);
+#else /* NANOFLANN_NO_THREADS */
+            throw std::runtime_error("Multithreading is disabled");
+#endif /* NANOFLANN_NO_THREADS */
         }
     }
 
@@ -2090,10 +2094,14 @@ class KDTreeSingleIndexDynamicAdaptor_
         }
         else
         {
+#ifndef NANOFLANN_NO_THREADS
             std::atomic<unsigned int> thread_count(0u);
             std::mutex                mutex;
             Base::root_node_ = this->divideTreeConcurrent(
                 *this, 0, Base::size_, Base::root_bbox_, thread_count, mutex);
+#else /* NANOFLANN_NO_THREADS */
+            throw std::runtime_error("Multithreading is disabled");
+#endif /* NANOFLANN_NO_THREADS */
         }
     }
 


### PR DESCRIPTION
Hello. I used nanoflann in my project and got a linker error because of pthreads usage (`std::async`). Since I don't use parallel construction and don't want to link my code with pthreads, I've just removed these calls from the library. I think that it might be convenient for others to do the same by just adding a define before including the header, so I made this PR.

I was thinking about adding the possibility to disable multi-threading to CMake, but I'm not an expert on it. If you think that it is necessary, I'll figure it out and add it to the PR.

Also, I've included in the readme all the ifdefs I found in the header.
