### PR TITLE
Fix middleSplit_ for same points

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1135,6 +1135,8 @@ class KDTreeBaseClass
     NodePtr divideTree(
         Derived& obj, const Offset left, const Offset right, BoundingBox& bbox)
     {
+        assert(left < obj.dataset_.kdtree_get_point_count());
+
         NodePtr node = obj.pool_.template allocate<Node>();  // allocate memory
         const auto dims = (DIM > 0 ? DIM : obj.dim_);
 
@@ -1306,7 +1308,7 @@ class KDTreeBaseClass
         for (Dimension i = 0; i < dims; ++i)
         {
             ElementType span = bbox[i].high - bbox[i].low;
-            if (span > (1 - EPS) * max_span)
+            if (span >= (1 - EPS) * max_span)
             {
                 ElementType min_elem_, max_elem_;
                 computeMinMax(obj, ind, count, i, min_elem_, max_elem_);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -815,3 +815,22 @@ TEST(kdtree, L2_concurrent_build_vs_L2)
         L2_concurrent_build_vs_L2_test<double>(100, 7);
     }
 }
+
+TEST(kdtree, same_points)
+{
+    using num_t         = double;
+    using point_cloud_t = PointCloud<num_t>;
+    using kdtree_t      = KDTreeSingleIndexAdaptor<
+             L2_Simple_Adaptor<num_t, point_cloud_t>, point_cloud_t, 3 /* dim */>;
+
+    point_cloud_t cloud;
+    cloud.pts.resize(16);
+    for (size_t i = 0; i < 16; ++i)
+    {
+        cloud.pts[i].x = -1.;
+        cloud.pts[i].y = 0.;
+        cloud.pts[i].z = 1.;
+    }
+
+    kdtree_t idx(3 /*dim*/, cloud);
+}


### PR DESCRIPTION
While https://github.com/jlblancoc/nanoflann/pull/220 decreases amount of `middleSplit_` calls, it also prevents finding correct `min_elem` and `max_elem` when 	`max_span == 0` and `span == 0`. What leads to wrong `cutval` calculation and out of range reads at `divideTree`.

The issue can be observed with the unit test executed under valgrind. 