### PR TITLE
CMake: Bump minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------------
 # Root CMake file for nanoflann
 # ----------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 # Extract library version into "NANOFLANN_VERSION"
 # -----------------------------------------------------


### PR DESCRIPTION
Avoids the deprecation message stating support for version<3.10 will become obsolete