### PR TITLE
Concurrent indexing refinement - release the slot while blocked and waiting

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1278,9 +1278,13 @@ class KDTreeBaseClass
 
             if (right_future.valid())
             {
+                // While this thread is blocked and waiting for the
+                // concurrent right sub-tree, allow for an additional
+                // worker thread elsewhere.
+                --thread_count;
+
                 // Block and wait for concurrent right sub-tree
                 node->child2 = right_future.get();
-                --thread_count;
             }
             else
             {


### PR DESCRIPTION
As a follow-up to our previous discussion for PR #236 

The idea here to allow _additional_ concurrent threads.

It's necessary to block and wait for the completion of the right child node.
But it seems reasonable and advantageous to allow an additional thread to start working while this one is done doing work.
It's just waiting until it can finalise some administration.

I've changed jobs and don't have the tools and data to test this change in detail.
So I would like to be clear that this change is essentially untried and untested.
I did take a look at [MRPT/nanoflann-benchmark](https://github.com/MRPT/nanoflann-benchmark) but I don't have Matlab or the datasets, looks like I'd need some help or advice getting going there.

But I am curious to know if this provides an additional performance improvement via additional CPU utilisation.
I am a little concerned this could result in a large number of (blocked) threads, beyond what's reasonable?

I'll leave this with you, to evaluate or not, at your discretion.