### PR TITLE
do not write to stderr

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -935,7 +935,6 @@ class PooledAllocator
             void* m = ::malloc(blocksize);
             if (!m)
             {
-                fprintf(stderr, "Failed to allocate memory.\n");
                 throw std::bad_alloc();
             }
 


### PR DESCRIPTION
This PR removed an `fprintf(stderr, ...)`, which seems accidentally left in, and also unnecessary.

Some projects have a hard requirement that all printing must go through overridable interfaces instead of writing directly to stdio/stderr. For example, CRAN would reject packages that use stderr directly.

While we could patch this out on our side (in igraph), it seemed appropriate to submit this change upstream. Let me know if it is acceptable.