### PR TITLE
Migrate node storage from PooledAllocator to std::vector

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -894,134 +894,6 @@ struct SearchParameters
 };
 /** @} */
 
-/** @addtogroup memalloc_grp Memory allocation
- * @{ */
-
-/**
- * Pooled storage allocator
- *
- * The following routines allow for the efficient allocation of storage in
- * small chunks from a specified pool.  Rather than allowing each structure
- * to be freed individually, an entire pool of storage is freed at once.
- * This method has two advantages over just using malloc() and free().  First,
- * it is far more efficient for allocating small objects, as there is
- * no overhead for remembering all the information needed to free each
- * object or consolidating fragmented memory.  Second, the decision about
- * how long to keep an object is made at the time of allocation, and there
- * is no need to track down all the objects to free them.
- *
- */
-class PooledAllocator
-{
-    static constexpr size_t WORDSIZE  = 16;  // WORDSIZE must >= 8
-    static constexpr size_t BLOCKSIZE = 8192;
-
-    /* We maintain memory alignment to word boundaries by requiring that all
-        allocations be in multiples of the machine wordsize.  */
-    /* Size of machine word in bytes.  Must be power of 2. */
-    /* Minimum number of bytes requested at a time from the system.  Must be
-     * multiple of WORDSIZE. */
-
-    using Size = size_t;
-
-    Size  remaining_ = 0;  //!< Number of bytes left in current block of storage
-    void* base_ = nullptr;  //!< Pointer to base of current block of storage
-    void* loc_  = nullptr;  //!< Current location in block to next allocate
-
-    void internal_init()
-    {
-        remaining_   = 0;
-        base_        = nullptr;
-        usedMemory   = 0;
-        wastedMemory = 0;
-    }
-
-   public:
-    Size usedMemory   = 0;
-    Size wastedMemory = 0;
-
-    /**
-        Default constructor. Initializes a new pool.
-     */
-    PooledAllocator() { internal_init(); }
-
-    /**
-     * Destructor. Frees all the memory allocated in this pool.
-     */
-    ~PooledAllocator() { free_all(); }
-
-    /** Frees all allocated memory chunks */
-    void free_all()
-    {
-        while (base_ != nullptr)
-        {
-            // Get pointer to prev block
-            void* prev = *(static_cast<void**>(base_));
-            ::free(base_);
-            base_ = prev;
-        }
-        internal_init();
-    }
-
-    /**
-     * Returns a pointer to a piece of new memory of the given size in bytes
-     * allocated from the pool.
-     */
-    void* malloc(const size_t req_size)
-    {
-        /* Round size up to a multiple of wordsize.  The following expression
-            only works for WORDSIZE that is a power of 2, by masking last bits
-           of incremented size to zero.
-         */
-        const Size size = (req_size + (WORDSIZE - 1)) & ~(WORDSIZE - 1);
-
-        /* Check whether a new block must be allocated.  Note that the first
-           word of a block is reserved for a pointer to the previous block.
-         */
-        if (size > remaining_)
-        {
-            wastedMemory += remaining_;
-
-            /* Allocate new storage. */
-            const Size blocksize =
-                size > BLOCKSIZE ? size + WORDSIZE : BLOCKSIZE + WORDSIZE;
-
-            // use the standard C malloc to allocate memory
-            void* m = ::malloc(blocksize);
-            if (!m) { throw std::bad_alloc(); }
-
-            /* Fill first word of new block with pointer to previous block. */
-            static_cast<void**>(m)[0] = base_;
-            base_                     = m;
-
-            remaining_ = blocksize - WORDSIZE;
-            loc_       = static_cast<char*>(m) + WORDSIZE;
-        }
-        void* rloc = loc_;
-        loc_       = static_cast<char*>(loc_) + size;
-        remaining_ -= size;
-
-        usedMemory += size;
-
-        return rloc;
-    }
-
-    /**
-     * Allocates (using this pool) a generic type T.
-     *
-     * Params:
-     *     count = number of instances to allocate.
-     * Returns: pointer (of type T*) to memory buffer
-     */
-    template <typename T>
-    T* allocate(const size_t count = 1)
-    {
-        T* mem = static_cast<T*>(this->malloc(sizeof(T) * count));
-        return mem;
-    }
-};
-/** @} */
-
 /** @addtogroup nanoflann_metaprog_grp Auxiliary metaprogramming stuff
  * @{ */
 
@@ -1066,8 +938,8 @@ class KDTreeBaseClass
      * buildIndex(). */
     void freeIndex(Derived& obj)
     {
-        obj.pool_.free_all();
-        obj.root_node_           = nullptr;
+        obj.pool_.clear();
+        obj.root_node_           = std::numeric_limits<node_index_t>::max();
         obj.size_at_index_build_ = 0;
     }
 
@@ -1080,9 +952,10 @@ class KDTreeBaseClass
      */
     std::vector<IndexType> vAcc_;
 
-    using Offset    = typename decltype(vAcc_)::size_type;
-    using Size      = typename decltype(vAcc_)::size_type;
-    using Dimension = int32_t;
+    using Offset       = typename decltype(vAcc_)::size_type;
+    using Size         = typename decltype(vAcc_)::size_type;
+    using Dimension    = int32_t;
+    using node_index_t = std::size_t;
 
     /*-------------------------------------------------------------------
      * Internal Data Structures
@@ -1114,8 +987,9 @@ class KDTreeBaseClass
             } sub;
         } node_type;
 
-        /** Child nodes (both=nullptr mean its a leaf node) */
-        Node *child1 = nullptr, *child2 = nullptr;
+        /** Child nodes (both=max() mean its a leaf node) */
+        node_index_t child1 = std::numeric_limits<node_index_t>::max();
+        node_index_t child2 = std::numeric_limits<node_index_t>::max();
     };
 
     using NodePtr      = Node*;
@@ -1126,7 +1000,7 @@ class KDTreeBaseClass
         ElementType low, high;
     };
 
-    NodePtr root_node_ = nullptr;
+    node_index_t root_node_ = std::numeric_limits<node_index_t>::max();
 
     Size leaf_max_size_ = 0;
 
@@ -1149,14 +1023,7 @@ class KDTreeBaseClass
     /** The KD-tree used to find neighbours */
     BoundingBox root_bbox_;
 
-    /**
-     * Pooled memory allocator.
-     *
-     * Using a pooled memory allocator is more efficient
-     * than allocating memory directly when there is a large
-     * number small of memory allocations.
-     */
-    PooledAllocator pool_;
+    std::vector<Node> pool_;
 
     /** Returns number of points in dataset  */
     Size size(const Derived& obj) const { return obj.size_; }
@@ -1177,9 +1044,7 @@ class KDTreeBaseClass
      */
     Size usedMemory(const Derived& obj) const
     {
-        return obj.pool_.usedMemory + obj.pool_.wastedMemory +
-               obj.dataset_.kdtree_get_point_count() *
-                   sizeof(IndexType);  // pool memory and vind array memory
+        return obj.pool_.capacity() * sizeof(Node);
     }
 
     /**
@@ -1208,20 +1073,21 @@ class KDTreeBaseClass
      * @param bbox bounding box used as input for splitting and output for
      * parent node
      */
-    NodePtr divideTree(
+    node_index_t divideTree(
         Derived& obj, const Offset left, const Offset right, BoundingBox& bbox)
     {
         assert(left < obj.dataset_.kdtree_get_point_count());
 
-        NodePtr node = obj.pool_.template allocate<Node>();  // allocate memory
+        size_t c_node = pool_.size();
+        pool_.push_back(Node());
         const auto dims = (DIM > 0 ? DIM : obj.dim_);
 
         /* If too few exemplars remain, then make this a leaf node. */
         if ((right - left) <= static_cast<Offset>(obj.leaf_max_size_))
         {
-            node->child1 = node->child2 = nullptr; /* Mark as leaf node. */
-            node->node_type.lr.left     = left;
-            node->node_type.lr.right    = right;
+            /* Already marked as leaf node by the Node() constructor */
+            pool_[c_node].node_type.lr.left  = left;
+            pool_[c_node].node_type.lr.right = right;
 
             // compute bounding-box of leaf points
             for (Dimension i = 0; i < dims; ++i)
@@ -1247,20 +1113,22 @@ class KDTreeBaseClass
             DistanceType cutval;
             middleSplit_(obj, left, right - left, idx, cutfeat, cutval, bbox);
 
-            node->node_type.sub.divfeat = cutfeat;
+            pool_[c_node].node_type.sub.divfeat = cutfeat;
 
             /* Recurse on left */
             BoundingBox left_bbox(bbox);
             left_bbox[cutfeat].high = cutval;
-            node->child1 = this->divideTree(obj, left, left + idx, left_bbox);
+            pool_[c_node].child1 =
+                this->divideTree(obj, left, left + idx, left_bbox);
 
             /* Recurse on right */
             BoundingBox right_bbox(bbox);
             right_bbox[cutfeat].low = cutval;
-            node->child2 = this->divideTree(obj, left + idx, right, right_bbox);
+            pool_[c_node].child2 =
+                this->divideTree(obj, left + idx, right, right_bbox);
 
-            node->node_type.sub.divlow  = left_bbox[cutfeat].high;
-            node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+            pool_[c_node].node_type.sub.divlow  = left_bbox[cutfeat].high;
+            pool_[c_node].node_type.sub.divhigh = right_bbox[cutfeat].low;
 
             for (Dimension i = 0; i < dims; ++i)
             {
@@ -1269,7 +1137,7 @@ class KDTreeBaseClass
             }
         }
 
-        return node;
+        return c_node;
     }
 
     /**
@@ -1284,12 +1152,13 @@ class KDTreeBaseClass
      * @param thread_count count of std::async threads
      * @param mutex mutex for mempool allocation
      */
-    NodePtr divideTreeConcurrent(
+    node_index_t divideTreeConcurrent(
         Derived& obj, const Offset left, const Offset right, BoundingBox& bbox,
         std::atomic<unsigned int>& thread_count, std::mutex& mutex)
     {
         std::unique_lock<std::mutex> lock(mutex);
-        NodePtr node = obj.pool_.template allocate<Node>();  // allocate memory
+        size_t                       c_node = pool_.size();
+        pool_.push_back(Node());
         lock.unlock();
 
         const auto dims = (DIM > 0 ? DIM : obj.dim_);
@@ -1297,9 +1166,9 @@ class KDTreeBaseClass
         /* If too few exemplars remain, then make this a leaf node. */
         if ((right - left) <= static_cast<Offset>(obj.leaf_max_size_))
         {
-            node->child1 = node->child2 = nullptr; /* Mark as leaf node. */
-            node->node_type.lr.left     = left;
-            node->node_type.lr.right    = right;
+            /* Already marked as leaf node by the Node() constructor */
+            pool_[c_node].node_type.lr.left  = left;
+            pool_[c_node].node_type.lr.right = right;
 
             // compute bounding-box of leaf points
             for (Dimension i = 0; i < dims; ++i)
@@ -1325,9 +1194,9 @@ class KDTreeBaseClass
             DistanceType cutval;
             middleSplit_(obj, left, right - left, idx, cutfeat, cutval, bbox);
 
-            node->node_type.sub.divfeat = cutfeat;
+            pool_[c_node].node_type.sub.divfeat = cutfeat;
 
-            std::future<NodePtr> right_future;
+            std::future<node_index_t> right_future;
 
             /* Recurse on right concurrently, if possible */
 
@@ -1349,26 +1218,26 @@ class KDTreeBaseClass
 
             BoundingBox left_bbox(bbox);
             left_bbox[cutfeat].high = cutval;
-            node->child1            = this->divideTreeConcurrent(
-                           obj, left, left + idx, left_bbox, thread_count, mutex);
+            pool_[c_node].child1    = this->divideTreeConcurrent(
+                obj, left, left + idx, left_bbox, thread_count, mutex);
 
             if (right_future.valid())
             {
                 /* Block and wait for concurrent right from above */
 
-                node->child2 = right_future.get();
+                pool_[c_node].child2 = right_future.get();
                 --thread_count;
             }
             else
             {
                 /* Otherwise, recurse on right in this thread */
 
-                node->child2 = this->divideTreeConcurrent(
+                pool_[c_node].child2 = this->divideTreeConcurrent(
                     obj, left + idx, right, right_bbox, thread_count, mutex);
             }
 
-            node->node_type.sub.divlow  = left_bbox[cutfeat].high;
-            node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+            pool_[c_node].node_type.sub.divlow  = left_bbox[cutfeat].high;
+            pool_[c_node].node_type.sub.divhigh = right_bbox[cutfeat].low;
 
             for (Dimension i = 0; i < dims; ++i)
             {
@@ -1377,7 +1246,7 @@ class KDTreeBaseClass
             }
         }
 
-        return node;
+        return c_node;
     }
 
     void middleSplit_(
@@ -1515,19 +1384,35 @@ class KDTreeBaseClass
     }
 
     static void save_tree(
-        const Derived& obj, std::ostream& stream, const NodeConstPtr tree)
+        const Derived& obj, std::ostream& stream, const node_index_t tree)
     {
-        save_value(stream, *tree);
-        if (tree->child1 != nullptr) { save_tree(obj, stream, tree->child1); }
-        if (tree->child2 != nullptr) { save_tree(obj, stream, tree->child2); }
+        save_value(stream, obj.pool_[tree]);
+        if (obj.pool_[tree].child1 != std::numeric_limits<node_index_t>::max())
+        {
+            save_tree(obj, stream, obj.pool_[tree].child1);
+        }
+        if (obj.pool_[tree].child2 != std::numeric_limits<node_index_t>::max())
+        {
+            save_tree(obj, stream, obj.pool_[tree].child2);
+        }
     }
 
-    static void load_tree(Derived& obj, std::istream& stream, NodePtr& tree)
+    static void load_tree(
+        Derived& obj, std::istream& stream, node_index_t& tree)
     {
-        tree = obj.pool_.template allocate<Node>();
-        load_value(stream, *tree);
-        if (tree->child1 != nullptr) { load_tree(obj, stream, tree->child1); }
-        if (tree->child2 != nullptr) { load_tree(obj, stream, tree->child2); }
+        node_index_t c_node = obj.pool_.size();
+        obj.pool_.push_back(Node());
+        load_value(stream, obj.pool_[c_node]);
+        if (obj.pool_[c_node].child1 !=
+            std::numeric_limits<node_index_t>::max())
+        {
+            load_tree(obj, stream, obj.pool_[c_node].child1);
+        }
+        if (obj.pool_[c_node].child2 !=
+            std::numeric_limits<node_index_t>::max())
+        {
+            load_tree(obj, stream, obj.pool_[c_node].child2);
+        }
     }
 
     /**  Stores the index in a binary file.
@@ -1542,7 +1427,8 @@ class KDTreeBaseClass
         save_value(stream, obj.root_bbox_);
         save_value(stream, obj.leaf_max_size_);
         save_value(stream, obj.vAcc_);
-        if (obj.root_node_) save_tree(obj, stream, obj.root_node_);
+        if (obj.root_node_ != std::numeric_limits<node_index_t>::max())
+            save_tree(obj, stream, obj.root_node_);
     }
 
     /**  Loads a previous index from a binary file.
@@ -1636,8 +1522,9 @@ class KDTreeSingleIndexAdaptor
     using DistanceType = typename Base::DistanceType;
     using IndexType    = typename Base::IndexType;
 
-    using Node    = typename Base::Node;
-    using NodePtr = Node*;
+    using Node         = typename Base::Node;
+    using NodePtr      = Node*;
+    using node_index_t = typename Base::node_index_t;
 
     using Interval = typename Base::Interval;
 
@@ -1722,7 +1609,12 @@ class KDTreeSingleIndexAdaptor
      */
     void buildIndex()
     {
-        Base::size_                = dataset_.kdtree_get_point_count();
+        Base::size_ = dataset_.kdtree_get_point_count();
+        size_t HeuristicNodeCount =
+            2 * ceil(Base::size_ / Base::leaf_max_size_);
+        // handle if the Base::size_ < Base::leaf_max_size_ using a std::max
+        // function
+        Base::pool_.reserve(std::max(HeuristicNodeCount, Base::size_));
         Base::size_at_index_build_ = Base::size_;
         init_vind();
         this->freeIndex(*this);
@@ -1774,7 +1666,7 @@ class KDTreeSingleIndexAdaptor
     {
         assert(vec);
         if (this->size(*this) == 0) return false;
-        if (!Base::root_node_)
+        if (Base::root_node_ == std::numeric_limits<node_index_t>::max())
             throw std::runtime_error(
                 "[nanoflann] findNeighbors() called before building the "
                 "index.");
@@ -1812,21 +1704,22 @@ class KDTreeSingleIndexAdaptor
     Size findWithinBox(RESULTSET& result, const BoundingBox& bbox) const
     {
         if (this->size(*this) == 0) return 0;
-        if (!Base::root_node_)
+        if (Base::root_node_ == std::numeric_limits<node_index_t>::max())
             throw std::runtime_error(
                 "[nanoflann] findWithinBox() called before building the "
                 "index.");
 
-        std::stack<NodePtr> stack;
+        std::stack<node_index_t> stack;
         stack.push(Base::root_node_);
 
         while (!stack.empty())
         {
-            const NodePtr node = stack.top();
+            const auto* node = &Base::pool_[stack.top()];
             stack.pop();
 
             // If this is a leaf node, then do check and return.
-            if (!node->child1)  // (if one node is nullptr, both are)
+            // (if one child is empty, both are)
+            if (node->child1 == std::numeric_limits<node_index_t>::max())
             {
                 for (Offset i = node->node_type.lr.left;
                      i < node->node_type.lr.right; ++i)
@@ -2020,19 +1913,21 @@ class KDTreeSingleIndexAdaptor
      */
     template <class RESULTSET>
     bool searchLevel(
-        RESULTSET& result_set, const ElementType* vec, const NodePtr node,
-        DistanceType mindist, distance_vector_t& dists,
-        const float epsError) const
+        RESULTSET& result_set, const ElementType* vec,
+        const node_index_t node_idx, DistanceType mindist,
+        distance_vector_t& dists, const float epsError) const
     {
+        const auto* node = &Base::pool_[node_idx];
         // If this is a leaf node, then do check and return.
-        if (!node->child1)  // (if one node is nullptr, both are)
+        // (if one child is empty, both are)
+        if (node->child1 == std::numeric_limits<node_index_t>::max())
         {
             for (Offset i = node->node_type.lr.left;
                  i < node->node_type.lr.right; ++i)
             {
                 const IndexType accessor = Base::vAcc_[i];  // reorder... : i;
                 DistanceType    dist     = distance_.evalMetric(
-                           vec, accessor, (DIM > 0 ? DIM : Base::dim_));
+                    vec, accessor, (DIM > 0 ? DIM : Base::dim_));
                 if (dist < result_set.worstDist())
                 {
                     if (!result_set.addPoint(dist, Base::vAcc_[i]))
@@ -2052,8 +1947,8 @@ class KDTreeSingleIndexAdaptor
         DistanceType diff1 = val - node->node_type.sub.divlow;
         DistanceType diff2 = val - node->node_type.sub.divhigh;
 
-        NodePtr      bestChild;
-        NodePtr      otherChild;
+        node_index_t bestChild;
+        node_index_t otherChild;
         DistanceType cut_dist;
         if ((diff1 + diff2) < 0)
         {
@@ -2185,8 +2080,9 @@ class KDTreeSingleIndexDynamicAdaptor_
     using Size      = typename Base::Size;
     using Dimension = typename Base::Dimension;
 
-    using Node    = typename Base::Node;
-    using NodePtr = Node*;
+    using Node         = typename Base::Node;
+    using NodePtr      = Node*;
+    using node_index_t = typename Base::node_index_t;
 
     using Interval = typename Base::Interval;
     /** Define "BoundingBox" as a fixed-size or variable-size container
@@ -2266,6 +2162,11 @@ class KDTreeSingleIndexDynamicAdaptor_
     void buildIndex()
     {
         Base::size_ = Base::vAcc_.size();
+        size_t HeuristicNodeCount =
+            2 * ceil(Base::size_ / Base::leaf_max_size_);
+        // handle if the Base::size_ < Base::leaf_max_size_ using a std::max
+        // function
+        Base::pool_.reserve(std::max(HeuristicNodeCount, Base::size_));
         this->freeIndex(*this);
         Base::size_at_index_build_ = Base::size_;
         if (Base::size_ == 0) return;
@@ -2319,7 +2220,8 @@ class KDTreeSingleIndexDynamicAdaptor_
     {
         assert(vec);
         if (this->size(*this) == 0) return false;
-        if (!Base::root_node_) return false;
+        if (Base::root_node_ == std::numeric_limits<node_index_t>::max())
+            return false;
         float epsError = 1 + searchParams.eps;
 
         // fixed or variable-sized container (depending on DIM)
@@ -2449,12 +2351,14 @@ class KDTreeSingleIndexDynamicAdaptor_
      */
     template <class RESULTSET>
     void searchLevel(
-        RESULTSET& result_set, const ElementType* vec, const NodePtr node,
-        DistanceType mindist, distance_vector_t& dists,
-        const float epsError) const
+        RESULTSET& result_set, const ElementType* vec,
+        const node_index_t node_idx, DistanceType mindist,
+        distance_vector_t& dists, const float epsError) const
     {
+        const auto* node = &Base::pool_[node_idx];
         // If this is a leaf node, then do check and return.
-        if (!node->child1)  // (if one node is nullptr, both are)
+        // (if one child is empty, both are)
+        if (node->child1 == std::numeric_limits<node_index_t>::max())
         {
             for (Offset i = node->node_type.lr.left;
                  i < node->node_type.lr.right; ++i)
@@ -2485,8 +2389,8 @@ class KDTreeSingleIndexDynamicAdaptor_
         DistanceType diff1 = val - node->node_type.sub.divlow;
         DistanceType diff2 = val - node->node_type.sub.divhigh;
 
-        NodePtr      bestChild;
-        NodePtr      otherChild;
+        node_index_t bestChild;
+        node_index_t otherChild;
         DistanceType cut_dist;
         if ((diff1 + diff2) < 0)
         {
@@ -2771,7 +2675,7 @@ struct KDTreeEigenMatrixAdaptor
     using num_t     = typename MatrixType::Scalar;
     using IndexType = typename MatrixType::Index;
     using metric_t  = typename Distance::template traits<
-        num_t, self_t, IndexType>::distance_t;
+         num_t, self_t, IndexType>::distance_t;
 
     using index_t = KDTreeSingleIndexAdaptor<
         metric_t, self_t,


### PR DESCRIPTION
## Description 
- **Simplification**: Eliminates the complexity associated with managing a custom PooledAllocator.
 - **Performance**: Increases data contiguity, which is expected to improve cache hit rates and overall performance.
 - **Implementation** Change: This necessitated moving from a pointer-based node organization (relying on memory addresses) to an index-based approach (relying on vector indices) to increase the memory without invalidating the entire tree

## Result
<img width="800" height="500" alt="a" src="https://github.com/user-attachments/assets/5d0cb5ed-f4c4-4c64-9d76-2ea2a6856617" />
<img width="800" height="500" alt="b" src="https://github.com/user-attachments/assets/5707d878-13ea-4719-8898-f49efc85d808" />
