### PR TITLE
Fix an invalid read.

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -797,6 +797,8 @@ void L2_concurrent_build_vs_L2_test(const size_t nSamples, const size_t DIM)
 template <typename num_t>
 void L2_dynamic_sorted_test(const size_t N, const size_t num_results)
 {
+    if (num_results == 0) return;
+
     PointCloud<num_t> cloud;
     generateRandomPointCloud(cloud, N);
 


### PR DESCRIPTION
If `num_results == 0` then `dynamic_idx` is empty, so `dynamic_idx[0]` does not exist. I caught this by building nanoflann with `-D_GLIBCXX_ASSERTIONS`.