### PR TITLE
Fix divideTree assertion failure with KDTreeSingleIndexDynamicAdaptor removePoint/addPoints

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1183,7 +1183,7 @@ class KDTreeBaseClass
      */
     NodePtr divideTree(Derived& obj, const Offset left, const Offset right, BoundingBox& bbox)
     {
-        assert(left < obj.dataset_.kdtree_get_point_count());
+        assert(obj.vAcc_.at(left) < obj.dataset_.kdtree_get_point_count());
 
         NodePtr    node = obj.pool_.template allocate<Node>();  // allocate memory
         const auto dims = (DIM > 0 ? DIM : obj.dim_);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1101,6 +1101,65 @@ TEST(kdtree, add_and_remove_points)
     EXPECT_EQ(actual, static_cast<size_t>(0));
 }
 
+// Test that repeated removePoint/addPoints cycles work correctly.
+// This exercises the case where the dynamic adaptor's internal pointCount_
+// grows beyond kdtree_get_point_count() due to re-adding removed points,
+// which must not cause assertion failures in divideTree.
+TEST(kdtree, dynamic_repeated_remove_readd)
+{
+    PointCloud<double> cloud;
+    // Create enough points that sub-trees accumulate entries exceeding N
+    const size_t N = 20;
+    for (size_t i = 0; i < N; i++)
+    {
+        cloud.pts.push_back({
+            static_cast<double>(i),
+            static_cast<double>(i * 2),
+            static_cast<double>(i * 3),
+        });
+    }
+
+    typedef KDTreeSingleIndexDynamicAdaptor<
+        L2_Simple_Adaptor<double, PointCloud<double>>, PointCloud<double>, 3>
+        my_kd_tree_t;
+
+    my_kd_tree_t index(3, cloud, KDTreeSingleIndexAdaptorParams(10));
+
+    // Repeatedly remove and re-add groups of points, simulating the pattern
+    // of temporarily excluding points from queries then restoring them.
+    for (size_t iteration = 0; iteration < 10; iteration++)
+    {
+        // Remove a group of points
+        for (size_t i = 0; i < N / 2; i++)
+        {
+            index.removePoint(i);
+        }
+
+        // Query while points are removed
+        const double                    query_pt[3] = {5.0, 10.0, 15.0};
+        std::vector<size_t>             ret_index(1);
+        std::vector<double>             out_dist_sqr(1);
+        nanoflann::KNNResultSet<double> resultSet(1);
+        resultSet.init(&ret_index[0], &out_dist_sqr[0]);
+        index.findNeighbors(resultSet, &query_pt[0]);
+
+        // The nearest point should be among the non-removed ones (indices N/2..N-1)
+        EXPECT_GE(ret_index[0], N / 2);
+
+        // Re-add the removed points
+        for (size_t i = 0; i < N / 2; i++)
+        {
+            index.addPoints(i, i);
+        }
+
+        // Query again - nearest should be index 5 (closest to query point)
+        nanoflann::KNNResultSet<double> resultSet2(1);
+        resultSet2.init(&ret_index[0], &out_dist_sqr[0]);
+        index.findNeighbors(resultSet2, &query_pt[0]);
+        EXPECT_EQ(ret_index[0], static_cast<size_t>(5));
+    }
+}
+
 TEST(kdtree, L2_concurrent_build_vs_bruteforce)
 {
     srand(static_cast<unsigned int>(time(nullptr)));


### PR DESCRIPTION
Disclosure: This is the outcome of me debugging an assertion failure (I encountered from 1.5.5 to 1.7.1) with the Claude Opus 4.6 LLM.

As far as I can tell, the minimal repro it generated for me makes sense.

I am not 100% confident about the fix to the assertion, so please do review that with extra scrutiny @yzabalotski and @jlblancoc (from #250).

LLM output below.

---

The assertion `assert(left < obj.dataset_.kdtree_get_point_count())` added in commit

    549a5e32 - Fix middleSplit_ for same points

(PR #250, released in v1.6.2) incorrectly fires when using `KDTreeSingleIndexDynamicAdaptor` with repeated `removePoint`/`addPoints` cycles on the same point indices.

Root cause: `addPoints` increments the internal `pointCount_` unconditionally, even when re-adding a previously removed point. This causes sub-tree `vAcc_` vectors to accumulate more entries than `dataset_.kdtree_get_point_count()`. When `buildIndex()` is called on such a sub-tree, it sets `size_ = vAcc_.size()` and calls `divideTree(*this, 0, size_, ...)`. In recursive calls, `left` (an offset into `vAcc_`) can exceed `kdtree_get_point_count()`, triggering the assertion.

However, the actual point *indices* stored in `vAcc_` are always valid (they are always < N). The assertion conflates the array offset with the dataset size, which is only a valid invariant for the static adaptor where `vAcc_` is a permutation of `[0, N)`.

Fix: Change the assertion to check what actually matters -- that the point index at `vAcc_[left]` is within bounds of the dataset.

Add a repro test that exercises repeated `removePoint`/`addPoints` cycles. That fails without the fix.

LLM: Found, repro'd, and fixed using Claude Opus 4.6, human review.