### PR TITLE
Fix duplicate-entry growth on removePoint/addPoints re-add cycles

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -64,7 +64,7 @@
 #include <ostream>
 #include <stack>
 #include <stdexcept>
-#include <unordered_set>
+#include <unordered_map>
 #include <vector>
 
 /** Library version: 0xMmP (M=Major,m=minor,P=patch) */
@@ -2519,8 +2519,11 @@ class KDTreeSingleIndexDynamicAdaptor
 
     /** treeIndex[idx] is the index of tree in which point at idx is stored.
      * treeIndex[idx]=-1 means that point has been removed. */
-    std::vector<int>        treeIndex_;
-    std::unordered_set<int> removedPoints_;
+    std::vector<int> treeIndex_;
+    /** Maps each currently-removed point index to the sub-tree that still
+     * physically holds it (removal is lazy). Used to reactivate the point in
+     * place if it is later re-added, instead of inserting a duplicate. */
+    std::unordered_map<IndexType, int> removedPoints_;
 
     KDTreeSingleIndexAdaptorParams index_params_;
 
@@ -2603,28 +2606,38 @@ class KDTreeSingleIndexDynamicAdaptor
     /** Add points to the set, Inserts all points from [start, end] */
     void addPoints(IndexType start, IndexType end)
     {
-        const Size count    = end - start + 1;
-        int        maxIndex = 0;
-        treeIndex_.resize(treeIndex_.size() + count);
+        int maxIndex = 0;
         for (IndexType idx = start; idx <= end; idx++)
         {
-            const int pos           = First0Bit(pointCount_);
-            maxIndex                = std::max(pos, maxIndex);
-            treeIndex_[pointCount_] = pos;
-
+            // If this index was previously removed, its point is still
+            // physically present in its sub-tree (removal is lazy and never
+            // deletes from vAcc_). Just clear the "removed" mark and restore its
+            // tree index. Re-inserting it would create a duplicate entry that
+            // grows the trees without bound and yields duplicate search results.
             const auto it = removedPoints_.find(idx);
             if (it != removedPoints_.end())
             {
+                treeIndex_[idx] = it->second;
                 removedPoints_.erase(it);
-                treeIndex_[idx] = pos;
+                continue;
             }
+
+            const int pos = First0Bit(pointCount_);
+            maxIndex      = std::max(pos, maxIndex);
+            if (treeIndex_.size() <= static_cast<size_t>(pointCount_))
+                treeIndex_.resize(static_cast<size_t>(pointCount_) + 1);
+            treeIndex_[pointCount_] = pos;
 
             for (int i = 0; i < pos; i++)
             {
                 for (int j = 0; j < static_cast<int>(index_[i].vAcc_.size()); j++)
                 {
-                    index_[pos].vAcc_.push_back(index_[i].vAcc_[j]);
-                    if (treeIndex_[index_[i].vAcc_[j]] != -1) treeIndex_[index_[i].vAcc_[j]] = pos;
+                    const IndexType e = index_[i].vAcc_[j];
+                    index_[pos].vAcc_.push_back(e);
+                    if (treeIndex_[e] != -1)
+                        treeIndex_[e] = pos;
+                    else
+                        removedPoints_[e] = pos;  // keep tombstone's tree index current
                 }
                 index_[i].vAcc_.clear();
             }
@@ -2643,8 +2656,11 @@ class KDTreeSingleIndexDynamicAdaptor
     void removePoint(size_t idx)
     {
         if (idx >= pointCount_) return;
-        removedPoints_.insert(idx);
-        treeIndex_[idx] = -1;
+        if (treeIndex_[idx] == -1) return;  // already removed
+        // Remember which sub-tree still physically holds this point, so it can
+        // be reactivated in place if re-added later (see addPoints).
+        removedPoints_[static_cast<IndexType>(idx)] = treeIndex_[idx];
+        treeIndex_[idx]                             = -1;
     }
 
     /**

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <map>
 #include <nanoflann.hpp>
+#include <set>
 
 #include "../examples/utils.h"
 
@@ -1158,6 +1159,64 @@ TEST(kdtree, dynamic_repeated_remove_readd)
         index.findNeighbors(resultSet2, &query_pt[0]);
         EXPECT_EQ(ret_index[0], static_cast<size_t>(5));
     }
+}
+
+// Re-adding a previously-removed point must reactivate the existing entry in
+// place, not insert a duplicate. Otherwise repeated remove/add cycles make the
+// internal index vectors grow without bound and cause the same point index to
+// be reported multiple times in radius/knn searches.
+TEST(kdtree, dynamic_readd_no_duplicates)
+{
+    PointCloud<double> cloud;
+    const size_t       N = 20;
+    for (size_t i = 0; i < N; i++)
+    {
+        cloud.pts.push_back({
+            static_cast<double>(i),
+            static_cast<double>(i * 2),
+            static_cast<double>(i * 3),
+        });
+    }
+
+    typedef KDTreeSingleIndexDynamicAdaptor<
+        L2_Simple_Adaptor<double, PointCloud<double>>, PointCloud<double>, 3>
+        my_kd_tree_t;
+
+    my_kd_tree_t index(3, cloud, KDTreeSingleIndexAdaptorParams(10));
+
+    // Helper: total number of entries physically stored across all sub-trees.
+    const auto total_stored_entries = [&index]() -> size_t
+    {
+        size_t total = 0;
+        for (const auto& subtree : index.getAllIndices()) total += subtree.vAcc_.size();
+        return total;
+    };
+
+    // Right after construction every point is stored exactly once.
+    EXPECT_EQ(total_stored_entries(), N);
+
+    // Repeatedly remove and re-add the same group of points.
+    for (size_t iteration = 0; iteration < 10; iteration++)
+    {
+        for (size_t i = 0; i < N / 2; i++) index.removePoint(i);
+        for (size_t i = 0; i < N / 2; i++) index.addPoints(i, i);
+    }
+
+    // The number of stored entries must not have grown: re-adding a removed
+    // point reuses its slot rather than appending a duplicate.
+    EXPECT_EQ(total_stored_entries(), N);
+
+    // A radius search large enough to cover every point must return each point
+    // index exactly once (no duplicates).
+    const double                                       query_pt[3] = {0.0, 0.0, 0.0};
+    std::vector<nanoflann::ResultItem<size_t, double>> matches;
+    nanoflann::RadiusResultSet<double, size_t>         resultSet(1e30, matches);
+    index.findNeighbors(resultSet, &query_pt[0]);
+
+    EXPECT_EQ(matches.size(), N);
+    std::set<size_t> unique_indices;
+    for (const auto& m : matches) unique_indices.insert(m.first);
+    EXPECT_EQ(unique_indices.size(), N);
 }
 
 TEST(kdtree, L2_concurrent_build_vs_bruteforce)


### PR DESCRIPTION
## Summary

Re-adding a previously-removed point now reactivates the existing entry **in place** instead of inserting a duplicate.

`removePoint` is a lazy deletion (`treeIndex_[idx] = -1`) that leaves the point physically present in its sub-tree's `vAcc_`. Re-adding it via `addPoints` re-inserted it — incrementing `pointCount_`, growing `treeIndex_`, and pushing the index into `vAcc_` again. Repeated remove/add cycles therefore caused unbounded growth of the internal vectors, duplicate results in radius/knn searches, and could eventually overflow `treeCount_` (the assertion fixed in #283 was an earlier casualty of the same growth).

Key observation: `treeIndex_`'s numeric value is only ever compared to `-1`, so reactivation just needs to restore a valid tree mark — no re-insertion or rebuild.

## Changes

- `removedPoints_`: `unordered_set<int>` → `unordered_map<IndexType,int>` (index → sub-tree that still holds it).
- `removePoint`: records the holding tree before marking `-1`; guards against double-removal.
- `addPoints`: if the index is currently removed, reactivate in place and skip re-insertion; the merge loop keeps a moved tombstone's stored tree current; `treeIndex_` is resized incrementally instead of by the batch count.
- New test `kdtree.dynamic_readd_no_duplicates`: asserts stored-entry count stays at N and a full-coverage radius search returns each index exactly once. Fails before this change (120 vs 20), passes after.

## Verification

- Full suite: 18/18 pass, including existing `add_and_remove_points` and #283's `dynamic_repeated_remove_readd`.
- `dynamic_pointcloud_example` (forward-only 1M-point usage) unchanged.
- `clang-format-14` applied (idempotent).

Fixes #284.