### PR TITLE
Fix three type/correctness bugs (operator=, First0Bit, findWithinBox)

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1782,7 +1782,7 @@ class KDTreeSingleIndexAdaptor
             }
             else
             {
-                const int  idx        = node->node_type.sub.divfeat;
+                const Dimension idx        = node->node_type.sub.divfeat;
                 const auto low_bound  = node->node_type.sub.divlow;
                 const auto high_bound = node->node_type.sub.divhigh;
 
@@ -2156,14 +2156,15 @@ class KDTreeSingleIndexDynamicAdaptor_
     /** Explicitly default the copy constructor */
     KDTreeSingleIndexDynamicAdaptor_(const KDTreeSingleIndexDynamicAdaptor_& rhs) = default;
 
-    /** Assignment operator definiton */
-    KDTreeSingleIndexDynamicAdaptor_ operator=(const KDTreeSingleIndexDynamicAdaptor_& rhs)
+    /** Assignment operator definition */
+    KDTreeSingleIndexDynamicAdaptor_& operator=(const KDTreeSingleIndexDynamicAdaptor_& rhs)
     {
+        if (this == &rhs) return *this;
         KDTreeSingleIndexDynamicAdaptor_ tmp(rhs);
         std::swap(Base::vAcc_, tmp.Base::vAcc_);
         std::swap(Base::leaf_max_size_, tmp.Base::leaf_max_size_);
         std::swap(index_params_, tmp.index_params_);
-        std::swap(treeIndex_, tmp.treeIndex_);
+        // treeIndex_ is a reference member and cannot be rebound; do not swap.
         std::swap(Base::size_, tmp.Base::size_);
         std::swap(Base::size_at_index_build_, tmp.Base::size_at_index_build_);
         std::swap(Base::root_node_, tmp.Base::root_node_);
@@ -2490,7 +2491,7 @@ class KDTreeSingleIndexDynamicAdaptor
 
    private:
     /** finds position of least significant unset bit */
-    int First0Bit(IndexType num)
+    int First0Bit(Size num)
     {
         int pos = 0;
         while (num & 1)


### PR DESCRIPTION
Three small independent correctness fixes, all internal with no public API change.

## §1.3 — `KDTreeSingleIndexDynamicAdaptor_::operator=` had two bugs

**Bug 1 — return by value instead of by reference:**
```cpp
// before
KDTreeSingleIndexDynamicAdaptor_ operator=(...)
// after
KDTreeSingleIndexDynamicAdaptor_& operator=(...)
```
Returning by value caused an extra copy on every assignment and broke chained
assignment (`a = b = c`).

**Bug 2 — `std::swap(treeIndex_, ...)` corrupted external state:**
`treeIndex_` is declared as `std::vector<int>&` (a reference to an externally-owned
vector managed by the outer `KDTreeSingleIndexDynamicAdaptor`). Swapping it with the
`tmp` copy's reference swapped the *contents* of both externally-owned vectors,
silently corrupting the parent adaptor's bookkeeping. The reference cannot be rebound,
so the swap is simply removed. A self-assignment guard is also added.

## §1.4 — `First0Bit(IndexType num)` silent truncation

`First0Bit` was called as `First0Bit(pointCount_)` where `pointCount_` is `Size`
(`size_t`), but the parameter type was `IndexType` (default `uint32_t`). Any index
count above 2^32 would be silently truncated, giving a wrong tree slot. Parameter
changed to `Size`.

## §1.5 — `findWithinBox` split-dimension `int` vs `Dimension`

```cpp
// before
const int idx = node->node_type.sub.divfeat;
// after
const Dimension idx = node->node_type.sub.divfeat;
```
`divfeat` is `Dimension` (`int32_t`). Using `int` is a narrowing assignment on
platforms where `int` is narrower, and is inconsistent with the two identical
lines in `searchLevel` that already use `Dimension`.

## Test plan
- [x] All 21 unit tests pass
🤖 Generated with [Claude Code](https://claude.com/claude-code)