### PR TITLE
saveIndex/loadIndex: add magic+version+type-size header, throw on mismatch

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -56,6 +56,7 @@
 #include <cassert>
 #include <cmath>  // for abs()
 #include <cstdint>
+#include <cstdio>  // snprintf
 #include <cstdlib>  // for abs()
 #include <functional>  // std::reference_wrapper
 #include <future>
@@ -1487,34 +1488,134 @@ class KDTreeBaseClass
         }
     }
 
-    /**  Stores the index in a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * when loading the index object it must be constructed associated to the
-     * same source of data points used while building it. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
+    /** Magic number written at the start of every saveIndex() stream.
+     *  Spells 'NFLN' in ASCII. */
+    static constexpr uint32_t SAVE_MAGIC = 0x4E464C4E;
+
+    /** Stores the index in a binary stream.
+     *
+     * The set of data points is NOT stored; when reloading, the index object
+     * must be constructed with the same dataset. See: examples/saveload_example.cpp
+     *
+     * \note **Portability limitations** (by design -- fixing them would require
+     *   a breaking format change):
+     *   - Files are NOT portable across different endianness (e.g. x86 little-endian
+     *     vs. big-endian SPARC/PowerPC). No byte-swapping is performed.
+     *   - Files are NOT portable across 32-bit vs. 64-bit platforms (sizeof(size_t)
+     *     differs).
+     *   - Files are NOT portable across different nanoflann versions; loadIndex()
+     *     throws if the version in the file does not match the library.
+     *   - Files are NOT portable across different template instantiations (e.g.
+     *     float vs. double IndexType/ElementType); loadIndex() throws on mismatch.
+     *
+     * \sa loadIndex
+     */
     void saveIndex(const Derived& obj, std::ostream& stream) const
     {
+        // 10-byte header: magic | version | sizeof_size_t | sizeof_IndexType
+        //                 | sizeof_ElementType | sizeof_DistanceType
+        // Use local copies: passing a static constexpr by const-ref ODR-uses it
+        // in C++11/14, which requires an out-of-class definition we cannot provide
+        // in a header-only library.
+        const uint32_t hdr_magic   = SAVE_MAGIC;
+        const uint32_t hdr_version = static_cast<uint32_t>(NANOFLANN_VERSION);
+        const uint8_t  hdr_sz_st   = static_cast<uint8_t>(sizeof(size_t));
+        const uint8_t  hdr_sz_idx  = static_cast<uint8_t>(sizeof(IndexType));
+        const uint8_t  hdr_sz_elem = static_cast<uint8_t>(sizeof(ElementType));
+        const uint8_t  hdr_sz_dist = static_cast<uint8_t>(sizeof(DistanceType));
+        save_value(stream, hdr_magic);
+        save_value(stream, hdr_version);
+        save_value(stream, hdr_sz_st);
+        save_value(stream, hdr_sz_idx);
+        save_value(stream, hdr_sz_elem);
+        save_value(stream, hdr_sz_dist);
+
         save_value(stream, obj.size_);
         save_value(stream, obj.dim_);
         save_value(stream, obj.root_bbox_);
         save_value(stream, obj.leaf_max_size_);
         save_value(stream, obj.vAcc_);
-        if (obj.root_node_) save_tree(obj, stream, obj.root_node_);
+        if (obj.root_node_)
+        {
+            save_tree(obj, stream, obj.root_node_);
+        }
     }
 
-    /**  Loads a previous index from a binary file.
-     *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so
-     * the index object must be constructed associated to the same source of
-     * data points used while building the index. See the example:
-     * examples/saveload_example.cpp \sa loadIndex  */
+    /** Loads an index previously saved with saveIndex() from a binary stream.
+     *
+     * The index object must be constructed associated to the same dataset that
+     * was used when building the saved index. See: examples/saveload_example.cpp
+     *
+     * \throws std::runtime_error if the stream does not start with the expected
+     *   magic number (wrong file or corrupt data), if the nanoflann version in
+     *   the file differs from the current library version, if the saved type
+     *   sizes (size_t, IndexType, ElementType, DistanceType) do not match the
+     *   current template instantiation, or if a read error occurs.
+     *
+     * \note See saveIndex() for portability limitations.
+     *
+     * \sa saveIndex
+     */
     void loadIndex(Derived& obj, std::istream& stream)
     {
+        // Validate header
+        uint32_t magic = 0;
+        load_value(stream, magic);
+        if (stream.fail() || magic != SAVE_MAGIC)
+        {
+            throw std::runtime_error(
+                "nanoflann loadIndex: invalid file (wrong magic number). "
+                "The stream was not written by nanoflann saveIndex().");
+        }
+
+        uint32_t file_version = 0;
+        load_value(stream, file_version);
+        if (file_version != static_cast<uint32_t>(NANOFLANN_VERSION))
+        {
+            char msg[200];
+            snprintf(
+                msg, sizeof(msg),
+                "nanoflann loadIndex: version mismatch "
+                "(file=0x%03X, library=0x%03X). Rebuild the index.",
+                file_version, static_cast<unsigned>(NANOFLANN_VERSION));
+            throw std::runtime_error(msg);
+        }
+
+        uint8_t sz_size_t = 0;
+        uint8_t sz_idx    = 0;
+        uint8_t sz_elem   = 0;
+        uint8_t sz_dist   = 0;
+        load_value(stream, sz_size_t);
+        load_value(stream, sz_idx);
+        load_value(stream, sz_elem);
+        load_value(stream, sz_dist);
+        if (sz_size_t != static_cast<uint8_t>(sizeof(size_t)) ||
+            sz_idx != static_cast<uint8_t>(sizeof(IndexType)) ||
+            sz_elem != static_cast<uint8_t>(sizeof(ElementType)) ||
+            sz_dist != static_cast<uint8_t>(sizeof(DistanceType)))
+        {
+            throw std::runtime_error(
+                "nanoflann loadIndex: type-size mismatch between saved index and "
+                "current template instantiation (sizeof size_t / IndexType / "
+                "ElementType / DistanceType differ). Rebuild the index.");
+        }
+
         load_value(stream, obj.size_);
         load_value(stream, obj.dim_);
         load_value(stream, obj.root_bbox_);
         load_value(stream, obj.leaf_max_size_);
         load_value(stream, obj.vAcc_);
-        if (obj.size_ > 0) load_tree(obj, stream, obj.root_node_);
+
+        if (obj.size_ > 0)
+        {
+            load_tree(obj, stream, obj.root_node_);
+        }
+
+        if (stream.fail())
+        {
+            throw std::runtime_error(
+                "nanoflann loadIndex: unexpected end of stream or read error.");
+        }
     }
 };
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -271,7 +271,8 @@ void rknn_L1_vs_bruteforce_test(
         for (size_t i = 0; i < nSamples; i++)
         {
             NUM dist = NUM(0.0);
-            for (size_t d = 0; d < DIM; d++) dist += static_cast<NUM>(std::abs(query_pt[d] - samples[i][d]));
+            for (size_t d = 0; d < DIM; d++)
+                dist += static_cast<NUM>(std::abs(query_pt[d] - samples[i][d]));
 
             if (dist < maxRadiusSqr) bf_nn.emplace(dist, i);
         }
@@ -286,7 +287,7 @@ void rknn_L1_vs_bruteforce_test(
     if (!bf_nn.empty())
     {
         const size_t compareCount = std::min<size_t>(nFound, bf_nn.size());
-        auto it = bf_nn.begin();
+        auto         it           = bf_nn.begin();
         for (size_t i = 0; i < compareCount; ++i, ++it)
         {
             // Distances must be in exact order:
@@ -297,8 +298,8 @@ void rknn_L1_vs_bruteforce_test(
             if (bf_idx2dist.find(ret_indexes[i]) != bf_idx2dist.end())
             {
                 EXPECT_NEAR(bf_idx2dist[ret_indexes[i]], out_dists_sqr[i], 1e-3)
-                    << "For: numToSearch=" << numToSearch << " out_dists_sqr[i]=" << out_dists_sqr[i]
-                    << "\n";
+                    << "For: numToSearch=" << numToSearch
+                    << " out_dists_sqr[i]=" << out_dists_sqr[i] << "\n";
             }
         }
     }
@@ -1413,4 +1414,60 @@ TEST(kdtree, dynamic_saveload_roundtrip)
 
     EXPECT_EQ(loaded_idx, expected_idx);
     EXPECT_NEAR(loaded_dist, expected_dist, 1e-10);
+}
+
+// loadIndex() must throw when the stream does not start with the nanoflann magic.
+TEST(kdtree, saveload_bad_magic)
+{
+    using num_t    = double;
+    using cloud_t  = PointCloud<num_t>;
+    using kdtree_t = KDTreeSingleIndexAdaptor<L2_Simple_Adaptor<num_t, cloud_t>, cloud_t, 3>;
+
+    cloud_t cloud;
+    generateRandomPointCloud(cloud, 100);
+
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    {
+        kdtree_t index(3, cloud, KDTreeSingleIndexAdaptorParams(10));
+        index.saveIndex(ss);
+    }
+
+    // Overwrite the first four bytes (magic) with garbage.
+    ss.seekp(0);
+    const uint32_t bad_magic = 0xDEADBEEF;
+    ss.write(reinterpret_cast<const char*>(&bad_magic), sizeof(bad_magic));
+    ss.seekg(0);
+
+    kdtree_t index(
+        3, cloud,
+        KDTreeSingleIndexAdaptorParams(10, KDTreeSingleIndexAdaptorFlags::SkipInitialBuildIndex));
+    EXPECT_THROW(index.loadIndex(ss), std::runtime_error);
+}
+
+// loadIndex() must throw when the nanoflann version in the file differs.
+TEST(kdtree, saveload_version_mismatch)
+{
+    using num_t    = double;
+    using cloud_t  = PointCloud<num_t>;
+    using kdtree_t = KDTreeSingleIndexAdaptor<L2_Simple_Adaptor<num_t, cloud_t>, cloud_t, 3>;
+
+    cloud_t cloud;
+    generateRandomPointCloud(cloud, 100);
+
+    std::stringstream ss(std::ios::in | std::ios::out | std::ios::binary);
+    {
+        kdtree_t index(3, cloud, KDTreeSingleIndexAdaptorParams(10));
+        index.saveIndex(ss);
+    }
+
+    // Overwrite the version field (bytes 4-7) with a fake version.
+    ss.seekp(4);
+    const uint32_t bad_version = 0x000;
+    ss.write(reinterpret_cast<const char*>(&bad_version), sizeof(bad_version));
+    ss.seekg(0);
+
+    kdtree_t index(
+        3, cloud,
+        KDTreeSingleIndexAdaptorParams(10, KDTreeSingleIndexAdaptorFlags::SkipInitialBuildIndex));
+    EXPECT_THROW(index.loadIndex(ss), std::runtime_error);
 }


### PR DESCRIPTION
## Problem

`saveIndex()` / `loadIndex()` write and read raw binary POD with no file signature, version field, or type-size check. Loading a file produced by a different nanoflann version, a different platform (32 vs 64-bit), or a different template instantiation (e.g. `float` vs `double`) silently populated the index with garbage data — no error, no warning, wrong search results.

## Solution

A 10-byte header is now prepended before the existing payload:

```
Offset  Size  Field
     0     4  magic = 0x4E464C4E  ('NFLN')
     4     4  NANOFLANN_VERSION   (current library version)
     8     1  sizeof(size_t)      (catches 32-bit vs 64-bit mismatch)
     9     1  sizeof(IndexType)
    10     1  sizeof(ElementType)
    11     1  sizeof(DistanceType)
```

`loadIndex()` reads and validates the header before touching any index state, and throws `std::runtime_error` with a diagnostic message on:

| Condition | Message |
|---|---|
| Wrong/missing magic | `"invalid file (wrong magic number)"` |
| Version mismatch | `"version mismatch (file=0xXXX, library=0xXXX). Rebuild the index."` |
| Type-size mismatch | `"type-size mismatch ... Rebuild the index."` |
| Read error / truncation | `"unexpected end of stream or read error"` |

### Portability — what is and is not handled

| Risk | Handled? |
|---|---|
| Wrong file or corrupt data | **Yes** — magic check |
| nanoflann version skew | **Yes** — version field |
| 32-bit vs 64-bit (`sizeof(size_t)`) | **Yes** — size fingerprint |
| `IndexType` / `ElementType` / `DistanceType` mismatch | **Yes** — size fingerprint |
| **Endianness** (e.g. x86 LE vs big-endian ARM/SPARC) | **No** — explicitly not handled; documented in `saveIndex()` Doxygen |
| Struct padding differences across compilers | Partially — type sizes are checked; pathological padding is not |

Endianness is a known limitation that would require a complete format redesign (byte-swapping all fields including floating-point). Given that the vast majority of nanoflann users are on little-endian x86/ARM, and a cross-endian solution is a breaking format change with significant complexity, it is explicitly out of scope and documented.

## Impact

**This is a format-breaking change.** Index files written by nanoflann < 1.9.0 will be rejected by `loadIndex()` with a clear error message asking the user to rebuild the index. This is strictly safer than the previous behavior (silent garbage).

## Tests added

- `saveload_bad_magic` — overwrites magic bytes, expects `std::runtime_error`
- `saveload_version_mismatch` — overwrites version field, expects `std::runtime_error`

All 23 tests pass.

## Checklist

- [x] All existing tests pass
- [x] Two new error-path tests added
- [x] clang-format-14 applied
- [x] No public API signature changes (saveIndex/loadIndex signatures unchanged)
- [x] Endianness limitation documented in Doxygen

🤖 Generated with [Claude Code](https://claude.com/claude-code)