### PR TITLE
Add saveIndex()/loadIndex() to the incremental k-d tree index

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -3127,6 +3127,142 @@ class KDTreeSingleIndexIncrementalAdaptor
 
     /** @} */
 
+    /** \name Persistence (index topology only; the dataset is NOT stored)
+     * @{ */
+
+    /** Magic number written at the start of every saveIndex() stream of this
+     *  incremental index. Distinct from the static KDTreeSingleIndexAdaptor's
+     *  SAVE_MAGIC so that loading the wrong kind of file fails fast with a
+     *  clear error instead of silently misinterpreting the bytes.
+     *  Spells 'NFLI' (nanoflann incremental) in ASCII. */
+    static constexpr uint32_t INCREMENTAL_SAVE_MAGIC = 0x4E464C49;
+
+    /** Serializes the tree *topology* (split axis, tombstone flags, and the
+     *  live/dead tree shape) to a binary stream. Point coordinates are NOT
+     *  stored: as with the static index's saveIndex(), the object must be
+     *  reattached to a dataset with the very same content before loadIndex()
+     *  is called on it.
+     *
+     *  Every other per-node field (bounding box, subtree size, tombstone
+     *  counts, coordinate cache, parent pointer) is recomputed on load instead
+     *  of stored, since they are all structural invariants derivable from the
+     *  fields above; this keeps the format independent of DIM being
+     *  compile-time fixed or runtime, unlike a raw struct byte-dump.
+     *
+     * \note Portability limitations as in the static index's saveIndex(): not
+     *   portable across endianness, 32- vs 64-bit size_t, nanoflann versions,
+     *   or IndexType/ElementType/DistanceType instantiations (checked, throws
+     *   on mismatch).
+     *
+     * \sa loadIndex
+     */
+    void saveIndex(std::ostream& stream) const
+    {
+        const uint32_t hdr_magic   = INCREMENTAL_SAVE_MAGIC;
+        const uint32_t hdr_version = static_cast<uint32_t>(NANOFLANN_VERSION);
+        const uint8_t  hdr_sz_st   = static_cast<uint8_t>(sizeof(size_t));
+        const uint8_t  hdr_sz_idx  = static_cast<uint8_t>(sizeof(IndexType));
+        const uint8_t  hdr_sz_elem = static_cast<uint8_t>(sizeof(ElementType));
+        const uint8_t  hdr_sz_dist = static_cast<uint8_t>(sizeof(DistanceType));
+        save_value(stream, hdr_magic);
+        save_value(stream, hdr_version);
+        save_value(stream, hdr_sz_st);
+        save_value(stream, hdr_sz_idx);
+        save_value(stream, hdr_sz_elem);
+        save_value(stream, hdr_sz_dist);
+
+        const Dimension dims = static_cast<Dimension>(this->veclen(*this));
+        save_value(stream, dims);
+
+        const uint8_t hasRoot = iroot_ ? 1 : 0;
+        save_value(stream, hasRoot);
+        if (iroot_) saveNode(stream, iroot_);
+    }
+
+    /** Loads a tree topology previously saved with saveIndex().
+     *
+     * \note Must be called on a freshly constructed index (mirrors the static
+     *   index's loadIndex() precondition): loading into an already-populated
+     *   tree is not supported and would leak its nodes. The object must
+     *   already be attached (via the constructor) to a dataset holding the
+     *   very same points that were indexed when saveIndex() was called.
+     *
+     * \throws std::runtime_error on a magic-number/version/type-size/
+     *   dimensionality mismatch, or a stream read error.
+     *
+     * \sa saveIndex
+     */
+    void loadIndex(std::istream& stream)
+    {
+        uint32_t magic = 0;
+        load_value(stream, magic);
+        if (stream.fail() || magic != INCREMENTAL_SAVE_MAGIC)
+        {
+            throw std::runtime_error(
+                "KDTreeSingleIndexIncrementalAdaptor::loadIndex: invalid file (wrong magic "
+                "number). The stream was not written by this class' saveIndex(), or was written "
+                "by the static KDTreeSingleIndexAdaptor instead.");
+        }
+
+        uint32_t file_version = 0;
+        load_value(stream, file_version);
+        if (file_version != static_cast<uint32_t>(NANOFLANN_VERSION))
+        {
+            char msg[200];
+            snprintf(
+                msg, sizeof(msg),
+                "KDTreeSingleIndexIncrementalAdaptor::loadIndex: version mismatch "
+                "(file=0x%03X, library=0x%03X). Rebuild the index.",
+                file_version, static_cast<unsigned>(NANOFLANN_VERSION));
+            throw std::runtime_error(msg);
+        }
+
+        uint8_t sz_size_t = 0;
+        uint8_t sz_idx    = 0;
+        uint8_t sz_elem   = 0;
+        uint8_t sz_dist   = 0;
+        load_value(stream, sz_size_t);
+        load_value(stream, sz_idx);
+        load_value(stream, sz_elem);
+        load_value(stream, sz_dist);
+        if (sz_size_t != static_cast<uint8_t>(sizeof(size_t)) ||
+            sz_idx != static_cast<uint8_t>(sizeof(IndexType)) ||
+            sz_elem != static_cast<uint8_t>(sizeof(ElementType)) ||
+            sz_dist != static_cast<uint8_t>(sizeof(DistanceType)))
+        {
+            throw std::runtime_error(
+                "KDTreeSingleIndexIncrementalAdaptor::loadIndex: type-size mismatch between "
+                "saved index and current template instantiation (sizeof size_t / IndexType / "
+                "ElementType / DistanceType differ). Rebuild the index.");
+        }
+
+        Dimension dims = 0;
+        load_value(stream, dims);
+        if (dims != static_cast<Dimension>(this->veclen(*this)))
+        {
+            throw std::runtime_error(
+                "KDTreeSingleIndexIncrementalAdaptor::loadIndex: dimensionality mismatch "
+                "between the saved index and this object's dataset.");
+        }
+
+        uint8_t hasRoot = 0;
+        load_value(stream, hasRoot);
+        iroot_ = hasRoot ? loadNode(stream, nullptr) : nullptr;
+
+        if (stream.fail())
+        {
+            throw std::runtime_error(
+                "KDTreeSingleIndexIncrementalAdaptor::loadIndex: unexpected end of stream or "
+                "read error.");
+        }
+
+        totalCount_ = iroot_ ? iroot_->subtree_size : 0;
+        liveCount_  = iroot_ ? iroot_->subtree_size - iroot_->invalid_count : 0;
+        syncRootBox();
+    }
+
+    /** @} */
+
    private:
     // --------------------------------------------------------------------
     //  Node allocation (bump-allocate from the pool, recycle via free-list)
@@ -3527,6 +3663,72 @@ class KDTreeSingleIndexIncrementalAdaptor
         collectAllRec(node->child2, out);
     }
 
+    // --------------------------------------------------------------------
+    //  Persistence (see saveIndex()/loadIndex())
+    // --------------------------------------------------------------------
+    /** Writes one node and its subtree. Only the fields that cannot be
+     *  derived from the rest are stored; see loadNode(). */
+    void saveNode(std::ostream& stream, const INode* n) const
+    {
+        save_value(stream, n->ptIdx);
+        save_value(stream, n->divfeat);
+        save_value(stream, n->deleted);
+        save_value(stream, n->treeDeleted);
+
+        const uint8_t hasChild1 = n->child1 ? 1 : 0;
+        save_value(stream, hasChild1);
+        if (n->child1) saveNode(stream, n->child1);
+
+        const uint8_t hasChild2 = n->child2 ? 1 : 0;
+        save_value(stream, hasChild2);
+        if (n->child2) saveNode(stream, n->child2);
+    }
+
+    /** Loads one node and its subtree. Reconstructs every field not written
+     *  by saveNode() (box, subtree_size, invalid_count, coordinate cache,
+     *  parent link, and the idx->node map entry) from invariants that hold
+     *  regardless of how the tree was originally built:
+     *   - subtree_size is always 1 + the children's (0 if absent).
+     *   - invalid_count equals subtree_size for a treeDeleted node (see
+     *     killSubtree()), otherwise it is this node's own deleted flag plus
+     *     the children's invalid_count.
+     *   - box is this node's point, unioned with the children's boxes.
+     */
+    INode* loadNode(std::istream& stream, INode* parent)
+    {
+        INode* n = allocNode();
+        load_value(stream, n->ptIdx);
+        load_value(stream, n->divfeat);
+        load_value(stream, n->deleted);
+        load_value(stream, n->treeDeleted);
+        n->parent = parent;
+
+        uint8_t hasChild1 = 0;
+        load_value(stream, hasChild1);
+        n->child1 = hasChild1 ? loadNode(stream, n) : nullptr;
+
+        uint8_t hasChild2 = 0;
+        load_value(stream, hasChild2);
+        n->child2 = hasChild2 ? loadNode(stream, n) : nullptr;
+
+        n->subtree_size = 1 + (n->child1 ? n->child1->subtree_size : 0) +
+                          (n->child2 ? n->child2->subtree_size : 0);
+        n->invalid_count = n->treeDeleted ? n->subtree_size
+                                          : static_cast<Size>(n->deleted ? 1 : 0) +
+                                                (n->child1 ? n->child1->invalid_count : 0) +
+                                                (n->child2 ? n->child2->invalid_count : 0);
+
+        initBoxToPoint(n);
+        unionBox(n, n->child1);
+        unionBox(n, n->child2);
+        cacheCoords(n);
+
+        ensureNodeMap(n->ptIdx);
+        nodeOfPoint_[n->ptIdx] = n;
+
+        return n;
+    }
+
     /** Build a balanced subtree over buf[lo,hi) (median split on widest axis). */
     INode* buildBalanced(
         std::vector<IndexType>& buf, size_t lo, size_t hi, Dimension depth, INode* parent)
@@ -3815,6 +4017,29 @@ class KDTreeSingleIndexIncrementalAdaptorMT
 
     /** Access the underlying active tree (e.g. for further query types). */
     const Inner& activeIndex() const { return *active_; }
+    /** @} */
+
+    /** \name Persistence (see the synchronous index's saveIndex()/loadIndex())
+     * @{ */
+
+    /** Blocks until any in-flight background rebuild is integrated (see
+     *  sync()), then serializes the active tree's topology. */
+    void saveIndex(std::ostream& stream)
+    {
+        sync();
+        active_->saveIndex(stream);
+    }
+
+    /** Blocks until any in-flight background rebuild is integrated, then loads
+     *  a previously saved topology into the active tree (see the synchronous
+     *  index's loadIndex() precondition: the active tree must be freshly
+     *  constructed / empty). */
+    void loadIndex(std::istream& stream)
+    {
+        sync();
+        active_->loadIndex(stream);
+        lastBuildLive_ = active_->size();
+    }
     /** @} */
 
     /** Set a callback invoked **on the background worker thread** on each freshly

--- a/tests/test_kdtree_incremental.cpp
+++ b/tests/test_kdtree_incremental.cpp
@@ -32,6 +32,8 @@
 //  Tests for KDTreeSingleIndexIncrementalAdaptor (single self-balancing tree)
 // ===========================================================================
 
+#include <sstream>
+
 #include "test_helpers.h"
 
 TEST(kdtree_incremental, add_knn_vs_bruteforce)
@@ -425,6 +427,211 @@ TEST(kdtree_incremental, pushdown_delete_into_killed_region)
     EXPECT_EQ(ri, newIdx);
     EXPECT_NEAR(rd, 0.0, 1e-9);
 }
+
+// ===========================================================================
+//  Tests for saveIndex()/loadIndex() (tree-topology persistence)
+// ===========================================================================
+
+// Round-trips a tree that has been through inserts, point removals AND a
+// box-trim (so it exercises both makeLeaf's depth-based divfeat and
+// buildBalanced's data-dependent widest-axis divfeat), and checks that a
+// freshly constructed index loaded from the saved stream returns identical
+// query results to the original for many random queries.
+TEST(kdtree_incremental, save_load_roundtrip_matches_queries)
+{
+    srand(2026);
+    inc_cloud_t  cloud;
+    inc_tree_t   index(3, cloud);
+    const size_t N = 3000;
+    for (size_t i = 0; i < N; ++i)
+        cloud.pts.push_back(
+            {20.0 * (rand() % 1000) / 1000.0 - 10.0, 20.0 * (rand() % 1000) / 1000.0 - 10.0,
+             20.0 * (rand() % 1000) / 1000.0 - 10.0});
+    index.addPoints(0, static_cast<uint32_t>(N) - 1);
+
+    // Remove ~15% of points at random (lazy tombstones, no full rebuild).
+    std::vector<uint32_t> order;
+    for (uint32_t i = 0; i < N; ++i) order.push_back(i);
+    std::mt19937 g(11);
+    std::shuffle(order.begin(), order.end(), g);
+    for (size_t i = 0; i < order.size() * 15 / 100; ++i) index.removePoint(order[i]);
+
+    // Trim a box (removeOutsideBox), which triggers scapegoat rebuilds
+    // (buildBalanced, data-dependent divfeat) on some subtrees.
+    inc_tree_t::BoundingBox keep;
+    for (int d = 0; d < 3; ++d)
+    {
+        keep[d].low  = -8;
+        keep[d].high = 8;
+    }
+    index.removeOutsideBox(keep);
+
+    ASSERT_GT(index.size(), 0u);
+
+    std::ostringstream oss(std::ios::binary);
+    index.saveIndex(oss);
+
+    // A fresh index attached to the very same dataset, per loadIndex()'s
+    // documented precondition.
+    inc_tree_t         loaded(3, cloud);
+    std::istringstream iss(oss.str(), std::ios::binary);
+    loaded.loadIndex(iss);
+
+    EXPECT_EQ(loaded.size(), index.size());
+    EXPECT_EQ(loaded.physicalSize(), index.physicalSize());
+
+    for (int t = 0; t < 300; ++t)
+    {
+        const double q[3] = {
+            20.0 * (rand() % 1000) / 1000.0 - 10.0, 20.0 * (rand() % 1000) / 1000.0 - 10.0,
+            20.0 * (rand() % 1000) / 1000.0 - 10.0};
+
+        uint32_t     ri_orig, ri_loaded;
+        double       rd_orig, rd_loaded;
+        const size_t n_orig   = index.knnSearch(q, 1, &ri_orig, &rd_orig);
+        const size_t n_loaded = loaded.knnSearch(q, 1, &ri_loaded, &rd_loaded);
+        ASSERT_EQ(n_orig, n_loaded);
+        if (n_orig == 0) continue;
+        EXPECT_EQ(ri_orig, ri_loaded);
+        EXPECT_NEAR(rd_orig, rd_loaded, 1e-9);
+
+        std::vector<nanoflann::ResultItem<uint32_t, double>> rad_orig, rad_loaded;
+        (void)index.radiusSearch(q, 2.0, rad_orig);
+        (void)loaded.radiusSearch(q, 2.0, rad_loaded);
+        EXPECT_EQ(rad_orig.size(), rad_loaded.size());
+    }
+}
+
+// A tree that was bulk-built with buildFromIndices() (no incremental inserts
+// at all): every internal node's divfeat comes from the widest-spread-axis
+// rule, never the depth-based default, so this exercises that path in
+// isolation.
+TEST(kdtree_incremental, save_load_after_buildFromIndices)
+{
+    inc_cloud_t  cloud;
+    inc_tree_t   index(3, cloud);
+    const size_t N = 500;
+    for (size_t i = 0; i < N; ++i)
+        cloud.pts.push_back(
+            {static_cast<double>(i % 10), static_cast<double>((i / 10) % 10),
+             static_cast<double>(i / 100)});
+    std::vector<uint32_t> idxs;
+    for (uint32_t i = 0; i < N; i += 2) idxs.push_back(i);  // even only
+    index.buildFromIndices(idxs);
+
+    std::ostringstream oss(std::ios::binary);
+    index.saveIndex(oss);
+
+    inc_tree_t         loaded(3, cloud);
+    std::istringstream iss(oss.str(), std::ios::binary);
+    loaded.loadIndex(iss);
+
+    EXPECT_EQ(loaded.size(), index.size());
+    for (uint32_t i = 0; i < N; ++i)
+    {
+        const double q[3] = {cloud.pts[i].x, cloud.pts[i].y, cloud.pts[i].z};
+        uint32_t     ri_orig, ri_loaded;
+        double       rd_orig, rd_loaded;
+        ASSERT_EQ(index.knnSearch(q, 1, &ri_orig, &rd_orig), 1u);
+        ASSERT_EQ(loaded.knnSearch(q, 1, &ri_loaded, &rd_loaded), 1u);
+        EXPECT_EQ(ri_orig, ri_loaded);
+    }
+}
+
+// Edge cases: an empty tree and a single-point tree must round-trip too.
+TEST(kdtree_incremental, save_load_empty_and_single_point)
+{
+    {
+        inc_cloud_t        cloud;
+        inc_tree_t         index(3, cloud);  // never populated
+        std::ostringstream oss(std::ios::binary);
+        index.saveIndex(oss);
+
+        inc_tree_t         loaded(3, cloud);
+        std::istringstream iss(oss.str(), std::ios::binary);
+        loaded.loadIndex(iss);
+        EXPECT_EQ(loaded.size(), 0u);
+        EXPECT_TRUE(loaded.empty());
+    }
+    {
+        inc_cloud_t cloud;
+        cloud.pts.push_back({1.0, 2.0, 3.0});
+        inc_tree_t index(3, cloud);
+        index.addPoint(0);
+
+        std::ostringstream oss(std::ios::binary);
+        index.saveIndex(oss);
+
+        inc_tree_t         loaded(3, cloud);
+        std::istringstream iss(oss.str(), std::ios::binary);
+        loaded.loadIndex(iss);
+        EXPECT_EQ(loaded.size(), 1u);
+
+        const double q[3] = {1.0, 2.0, 3.0};
+        uint32_t     ri;
+        double       rd;
+        ASSERT_EQ(loaded.knnSearch(q, 1, &ri, &rd), 1u);
+        EXPECT_EQ(ri, 0u);
+        EXPECT_NEAR(rd, 0.0, 1e-12);
+    }
+}
+
+// loadIndex() must reject a stream that was not written by saveIndex()
+// (wrong magic number), instead of silently misinterpreting the bytes.
+TEST(kdtree_incremental, load_index_wrong_magic_throws)
+{
+    inc_cloud_t cloud;
+    cloud.pts.push_back({0.0, 0.0, 0.0});
+    inc_tree_t index(3, cloud);
+    index.addPoint(0);
+
+    std::istringstream garbage(std::string(64, '\xAB'), std::ios::binary);
+    EXPECT_THROW(index.loadIndex(garbage), std::runtime_error);
+}
+
+#ifndef NANOFLANN_NO_THREADS
+// The MT wrapper's saveIndex()/loadIndex() must block on any in-flight
+// background rebuild and (de)serialize the active tree transparently.
+TEST(kdtree_incremental, async_mt_save_load_roundtrip)
+{
+    using mt_tree_t = nanoflann::KDTreeSingleIndexIncrementalAdaptorMT<
+        nanoflann::L2_Simple_Adaptor<double, inc_cloud_t>, inc_cloud_t, 3, uint32_t>;
+
+    inc_cloud_t cloud;
+    cloud.pts.reserve(200000);
+    mt_tree_t index(3, cloud, nanoflann::KDTreeIncrementalIndexParams(0.8f, 0.5f), 1.3, 2000);
+
+    std::mt19937                           g(4321);
+    std::uniform_real_distribution<double> U(0.0, 10.0);
+    for (int frame = 0; frame < 10; ++frame)
+    {
+        const uint32_t start = static_cast<uint32_t>(cloud.pts.size());
+        for (int i = 0; i < 1500; ++i) cloud.pts.push_back({U(g), U(g), U(g)});
+        const uint32_t end = static_cast<uint32_t>(cloud.pts.size()) - 1;
+        index.addPoints(start, end);  // large enough batches to trigger a background rebuild
+    }
+
+    std::ostringstream oss(std::ios::binary);
+    index.saveIndex(oss);  // blocks on any pending rebuild internally
+
+    mt_tree_t loaded(3, cloud, nanoflann::KDTreeIncrementalIndexParams(0.8f, 0.5f), 1.3, 2000);
+    std::istringstream iss(oss.str(), std::ios::binary);
+    loaded.loadIndex(iss);
+
+    EXPECT_EQ(loaded.size(), index.size());
+
+    for (int t = 0; t < 200; ++t)
+    {
+        const double q[3] = {U(g), U(g), U(g)};
+        uint32_t     ri_orig, ri_loaded;
+        double       rd_orig, rd_loaded;
+        ASSERT_EQ(index.knnSearch(q, 1, &ri_orig, &rd_orig), 1u);
+        ASSERT_EQ(loaded.knnSearch(q, 1, &ri_loaded, &rd_loaded), 1u);
+        EXPECT_EQ(ri_orig, ri_loaded);
+        EXPECT_NEAR(rd_orig, rd_loaded, 1e-9);
+    }
+}
+#endif  // NANOFLANN_NO_THREADS
 
 #ifndef NANOFLANN_NO_THREADS
 TEST(kdtree_incremental, async_mt_vs_bruteforce_under_churn)

--- a/tests/test_kdtree_incremental.cpp
+++ b/tests/test_kdtree_incremental.cpp
@@ -589,6 +589,102 @@ TEST(kdtree_incremental, load_index_wrong_magic_throws)
     EXPECT_THROW(index.loadIndex(garbage), std::runtime_error);
 }
 
+// loadIndex()'s remaining header/stream validation branches: version
+// mismatch, type-size mismatch, dimensionality mismatch, and truncated
+// (EOF) node data. Each is triggered in isolation by corrupting exactly the
+// field the corresponding check inspects, starting from an otherwise-valid
+// saved stream (or, for the dimensionality check, a hand-built minimal
+// header) so no other check fires first.
+TEST(kdtree_incremental, load_index_version_mismatch_throws)
+{
+    inc_cloud_t cloud;
+    cloud.pts.push_back({1.0, 2.0, 3.0});
+    inc_tree_t index(3, cloud);
+    index.addPoint(0);
+
+    std::ostringstream oss(std::ios::binary);
+    index.saveIndex(oss);
+    std::string blob = oss.str();
+
+    // Bytes [4,8) hold the uint32_t library version; flipping them all
+    // guarantees a different (and, for any sane build, invalid) value.
+    ASSERT_GE(blob.size(), 8u);
+    for (size_t i = 4; i < 8; ++i) blob[i] = static_cast<char>(~blob[i]);
+
+    inc_tree_t         loaded(3, cloud);
+    std::istringstream iss(blob, std::ios::binary);
+    EXPECT_THROW(loaded.loadIndex(iss), std::runtime_error);
+}
+
+TEST(kdtree_incremental, load_index_type_size_mismatch_throws)
+{
+    inc_cloud_t cloud;
+    cloud.pts.push_back({1.0, 2.0, 3.0});
+    inc_tree_t index(3, cloud);
+    index.addPoint(0);
+
+    std::ostringstream oss(std::ios::binary);
+    index.saveIndex(oss);
+    std::string blob = oss.str();
+
+    // Byte [8] holds sizeof(size_t) as written by the saver; 0xFF cannot be a
+    // real size_t width.
+    ASSERT_GE(blob.size(), 9u);
+    blob[8] = '\xFF';
+
+    inc_tree_t         loaded(3, cloud);
+    std::istringstream iss(blob, std::ios::binary);
+    EXPECT_THROW(loaded.loadIndex(iss), std::runtime_error);
+}
+
+TEST(kdtree_incremental, load_index_dimensionality_mismatch_throws)
+{
+    // A hand-built minimal, empty-tree header (magic, version, the four
+    // size bytes, a wrong `dims`, hasRoot=0) isolates the dimensionality
+    // check from every other one, which all see correct values.
+    std::ostringstream oss(std::ios::binary);
+    const uint32_t     magic =
+        inc_tree_t::INCREMENTAL_SAVE_MAGIC;  // avoid ODR-using the static constexpr
+    nanoflann::save_value(oss, magic);
+    nanoflann::save_value(oss, static_cast<uint32_t>(NANOFLANN_VERSION));
+    nanoflann::save_value(oss, static_cast<uint8_t>(sizeof(size_t)));
+    nanoflann::save_value(oss, static_cast<uint8_t>(sizeof(uint32_t)));  // IndexType
+    nanoflann::save_value(oss, static_cast<uint8_t>(sizeof(double)));  // ElementType
+    nanoflann::save_value(oss, static_cast<uint8_t>(sizeof(double)));  // DistanceType
+    nanoflann::save_value(oss, static_cast<inc_tree_t::Dimension>(99));  // wrong dims (!= 3)
+    nanoflann::save_value(oss, static_cast<uint8_t>(0));  // hasRoot = false
+
+    inc_cloud_t        cloud;
+    inc_tree_t         loaded(3, cloud);
+    std::istringstream iss(oss.str(), std::ios::binary);
+    EXPECT_THROW(loaded.loadIndex(iss), std::runtime_error);
+}
+
+TEST(kdtree_incremental, load_index_truncated_node_data_throws)
+{
+    inc_cloud_t cloud;
+    for (int i = 0; i < 20; ++i) cloud.pts.push_back({double(i), double(i), double(i)});
+    inc_tree_t index(3, cloud);
+    index.addPoints(0, 19);
+
+    std::ostringstream oss(std::ios::binary);
+    index.saveIndex(oss);
+    std::string blob = oss.str();
+
+    // The header (through hasRoot) is: magic + version + 4 size bytes + dims
+    // + hasRoot. Keep it intact (so every prior check passes and hasRoot=1
+    // is read correctly), but cut off a few bytes into the first node's
+    // data, so loadNode()'s recursive reads eventually hit EOF.
+    const size_t headerSize = sizeof(uint32_t) + sizeof(uint32_t) + 4 * sizeof(uint8_t) +
+                              sizeof(inc_tree_t::Dimension) + sizeof(uint8_t);
+    ASSERT_GT(blob.size(), headerSize + 3);
+    blob.resize(headerSize + 3);
+
+    inc_tree_t         loaded(3, cloud);
+    std::istringstream iss(blob, std::ios::binary);
+    EXPECT_THROW(loaded.loadIndex(iss), std::runtime_error);
+}
+
 #ifndef NANOFLANN_NO_THREADS
 // The MT wrapper's saveIndex()/loadIndex() must block on any in-flight
 // background rebuild and (de)serialize the active tree transparently.


### PR DESCRIPTION
## Summary
- `KDTreeSingleIndexIncrementalAdaptor` had no way to persist/restore its tree: the base class's `saveIndex()`/`loadIndex()` operate on `root_node_`/`vAcc_`, which this adaptor never populates (it keeps its own `iroot_`/`INode` tree instead), so they were silent no-ops.
- Adds `saveIndex(std::ostream&) const` / `loadIndex(std::istream&)` directly on the incremental adaptor, serializing only the fields that cannot be derived (`ptIdx`, `divfeat`, `deleted`, `treeDeleted`, child-presence bits); bounding box, `subtree_size`, `invalid_count`, the coordinate cache and parent links are recomputed on load from documented invariants. Uses its own magic number (distinct from the static index's `SAVE_MAGIC`) so loading the wrong file format throws instead of misinterpreting bytes.
- Adds matching forwarders on `KDTreeSingleIndexIncrementalAdaptorMT` that block on any in-flight background rebuild first.
- Motivating use case: `mola::IncrementalPointCloud` (a LiDAR-odometry local map in [MOLAorg/mola](https://github.com/MOLAorg/mola)) wants to bake this index into its on-disk map format so it isn't rebuilt from scratch (O(N log N)) on every load.

## Test plan
- [x] New unit tests in `tests/test_kdtree_incremental.cpp`: round-trip after mixed inserts/removals/box-trim (covers both `makeLeaf`'s depth-based `divfeat` and `buildBalanced`'s data-dependent widest-axis `divfeat`) with knn/radius query parity checks; round-trip after a pure `buildFromIndices()` bulk build; empty-tree and single-point edge cases; wrong-magic load throws; MT-wrapper round-trip.
- [x] Full existing test suite passes locally (`nanoflann_unit_tests`, 40/40).
- [x] `clang-format-14` applied to both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpmr4jpUm5kUwMTghYbTYp