### PR TITLE
Add opt-in NANOFLANN_INSTALL_EXAMPLES option

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,8 @@
 find_package(Eigen3 QUIET) # optional, for examples only
 
+option(NANOFLANN_INSTALL_EXAMPLES "Install the example binaries" OFF)
+set(INSTALL_EXAMPLES_DIR "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/examples" CACHE STRING "Example install folder")
+
 # examples:
 macro(DefineExample _NAME)
 	add_executable(${_NAME} ${_NAME}.cpp)
@@ -10,6 +13,10 @@ macro(DefineExample _NAME)
 			-Wall -Wextra -Wpedantic -Wconversion -Wshadow)
 	else()
 		target_compile_options(${_NAME} PRIVATE /W4)
+	endif()
+	if(NANOFLANN_INSTALL_EXAMPLES)
+		install(TARGETS ${_NAME}
+			DESTINATION ${INSTALL_EXAMPLES_DIR})
 	endif()
 endmacro()
 


### PR DESCRIPTION
## Summary
- Adds an opt-in CMake option `NANOFLANN_INSTALL_EXAMPLES` (default `OFF`) that, when enabled, installs the example binaries under `${CMAKE_INSTALL_LIBDIR}/nanoflann/examples`.
- Default behavior is unchanged: examples are still built for local testing/CI but not installed unless explicitly requested.

## Related
Related to #307, which proposed unconditionally installing the examples. That PR was closed because installing binaries by default isn't expected behavior for a minimalist, header-only library. This PR keeps the useful part of that request (the ability to install examples for those who want it) but makes it opt-in, and does not carry over the unrelated `find_package(Eigen3 QUIET)` → `REQUIRED` change from that PR, since Eigen3 is intentionally optional (only `matrix_example` depends on it).

## Test plan
- [x] `cmake ..` (default) configures cleanly, `NANOFLANN_INSTALL_EXAMPLES` defaults to `OFF`.
- [x] `cmake .. -DNANOFLANN_INSTALL_EXAMPLES=ON` configures cleanly.