### PR TITLE
chore(ros): rename the ROS package to nanoflann_vendor

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,9 +1,21 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!-- This file allows nanoflann to be built inside a ROS workspace and
-     indexed by the ROS build farm as a plain CMake package. -->
+     indexed by the ROS build farm as a plain CMake package.
+
+     The package is named "nanoflann_vendor", not "nanoflann", because
+     "nanoflann" is already a rosdep key (rosdep/base.yaml) resolving to the
+     distribution's own libnanoflann-dev. That key wins over a ROS package of
+     the same name, so <depend>nanoflann</depend> never selects this package
+     and nothing can actually depend on it. The _vendor suffix is what the
+     ROS 2 core uses for exactly this situation (sqlite3_vendor,
+     rviz_assimp_vendor, sdl2_vendor, libcurl_vendor, ...).
+
+     This only changes the ROS package name. The CMake package is still found
+     as find_package(nanoflann), since that name comes from the CMake project,
+     not from here. -->
 <package format="3">
-  <name>nanoflann</name>
+  <name>nanoflann_vendor</name>
   <version>1.12.0</version>
   <description>
     nanoflann: a C++11 header-only library for Nearest Neighbor (NN) search


### PR DESCRIPTION
## Problem

`nanoflann` is **already a rosdep key**. From `rosdep/base.yaml`:

```yaml
nanoflann:
  ubuntu:
    '*': [libnanoflann-dev]
```

That key wins over a released ROS package of the same name, so `<depend>nanoflann</depend>` always resolves to the distribution's apt package and **never** to this one. Consequence: `ros-<distro>-nanoflann` is currently dead weight in all five active distros — zero packages in the ROS apt repositories depend on it, and none can.

### This already broke something

`mrpt_ros` 2.15.20 stopped vendoring its embedded nanoflann copy and switched to `<depend>nanoflann</depend>`, intending to pick up this package. Bloom resolved it to `libnanoflann-dev`, which on Ubuntu jammy is **1.4.2**. You can see it in the generated `debian/control` at `release/humble/mrpt_libmath/2.15.20-1`:

```
Build-Depends: ..., libnanoflann-dev, ...
Depends: ..., libnanoflann-dev, ...
```

Since MRPT's radius-limited kNN needs nanoflann ≥ 1.5.1, the effective version on Humble went *backwards* 1.9.0 → 1.4.2, and `mrpt::math::KDTreeCapable::kdTreeNClosestPoint3DIdx()` now throws `"RKNN search requires nanoflann>=1.5.1"` at runtime. That takes `mola_metric_maps`' `KeyframePointCloudMap` down with it ([buildfarm Hdev #489](https://build.ros2.org/job/Hdev__mola__ubuntu_jammy_amd64/489/)).

## Fix

Rename the ROS package to `nanoflann_vendor`, which is the ROS 2 convention for exactly this collision:

| library | rosdep key resolves to | ROS package |
|---|---|---|
| sqlite3 | `sqlite3` | `sqlite3_vendor` |
| assimp | `libassimp-dev` | `rviz_assimp_vendor` |
| sdl2 | `libsdl2-dev` | `sdl2_vendor` |
| curl | `libcurl4-openssl-dev` | `libcurl_vendor` |
| **nanoflann** | **`libnanoflann-dev`** | **`nanoflann` ← collides** |

nanoflann is currently the only vendored library in the ROS 2 ecosystem released under its bare, already-taken name. After the rename, a consumer that specifically wants a modern nanoflann (rather than whatever the distro ships) can say `<depend>nanoflann_vendor</depend>` and actually get it.

**This only changes the ROS package name.** The CMake package name comes from the CMake project, so `find_package(nanoflann)` and the `nanoflann::nanoflann` target are untouched — no consumer source change is needed.

## Follow-up (not in this PR)

Once this is merged, per distro (humble, jazzy, kilted, lyrical, rolling):

1. `bloom-release nanoflann_vendor` — bloom opens the rosdistro PR adding the new entry.
2. A separate rosdistro PR dropping the now-orphaned `nanoflann` entry.

A rosdistro PR cannot do the rename by itself: the entry name mirrors `<name>` here, and the release repo's tags are keyed on it (`release/<distro>/nanoflann/<version>`), so it has to start from this repo.

Worth deciding separately: whether MRPT should then depend on `nanoflann_vendor` on old distros, and how to keep its headers from colliding with `libnanoflann-dev`'s if both end up installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the package metadata to use the `nanoflann_vendor` name.
  * Added clarification about naming conventions, dependency resolution, and the unchanged CMake package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->