### PR TITLE
Fix crash and wrong results with unsigned ElementType (alternative to #314)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package nanoflann
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* fix: crash (heap-buffer-overflow) while building an index over an unsigned
+  ``ElementType`` such as ``uint8_t``. The cut dimension was selected with a
+  negative sentinel that wraps around for unsigned types, leading to a
+  degenerate cut and an underflow in the partition loop.
+* fix: overflow of the split midpoint and of the metric subtractions for wide
+  integral ``ElementType`` (``uint32_t``, ``uint64_t``).
+* The distance adaptors now ``static_assert`` that ``_DistanceType`` is signed,
+  as their documentation already required. With an unsigned ``ElementType`` it
+  must be given explicitly, e.g.
+  ``L2_Simple_Adaptor<uint8_t, MyCloud, int32_t>``.
+
 1.12.1 (2026-08-08)
 -------------------
 * docs: badges updates to use nanoflann_vendor

--- a/README.md
+++ b/README.md
@@ -118,6 +118,22 @@ Refer to the examples below or to the C++ API of [nanoflann::KDTreeSingleIndexAd
     * Can be used to receive a callback for each point found in range. This may be more efficient in some situations instead of building a huge vector of pairs with the results.
     * [nanoflann::KDTreeSingleIndexAdaptor<>](https://jlblancoc.github.io/nanoflann/classnanoflann_1_1KDTreeSingleIndexAdaptor.html)`::findWithinBox()` [New in 1.8.0]: Optimized search within a given axis-aligned bound box.
   * Working with 2D and 3D point clouds or N-dimensional data sets.
+  * Working with integral element types, including unsigned ones. Since
+    `_DistanceType` defaults to the element type and must be **signed**, an
+    unsigned element type requires passing it explicitly, wide enough for the
+    distances of the actual coordinate range, e.g.
+    `nanoflann::L2_Simple_Adaptor<uint8_t, MyCloud, int32_t>`. To use it
+    through the `nanoflann::metric_*` tags, define your own tag:
+    ```cpp
+    struct my_metric_L2 : public nanoflann::Metric
+    {
+        template <class T, class DataSource, typename IndexType = size_t>
+        struct traits
+        {
+            using distance_t = nanoflann::L2_Simple_Adaptor<T, DataSource, int32_t, IndexType>;
+        };
+    };
+    ```
   * Working directly with `Eigen::Matrix<>` classes (matrices and vectors-of-vectors).
   * Working with dynamic point clouds without a need to rebuild entire kd-tree index. Two options:
     * `nanoflann::KDTreeSingleIndexDynamicAdaptor<>`: the Bentley–Saxe "logarithmic forest" of static sub-trees.

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1332,8 +1332,8 @@ class KDTreeBaseClass
         /* Which child branch should be taken first? */
         Dimension    idx   = node->node_type.sub.divfeat;
         ElementType  val   = vec[idx];
-        DistanceType diff1 = val - node->node_type.sub.divlow;
-        DistanceType diff2 = val - node->node_type.sub.divhigh;
+        DistanceType diff1 = detail::diff_as<DistanceType>(val, node->node_type.sub.divlow);
+        DistanceType diff2 = detail::diff_as<DistanceType>(val, node->node_type.sub.divhigh);
 
         NodePtr      bestChild;
         NodePtr      otherChild;
@@ -1430,8 +1430,8 @@ class KDTreeBaseClass
         Derived& obj, NodePtr node, const Dimension cutfeat, const BoundingBox& left_bbox,
         const BoundingBox& right_bbox, BoundingBox& bbox)
     {
-        node->node_type.sub.divlow  = left_bbox[cutfeat].high;
-        node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+        node->node_type.sub.divlow  = static_cast<DistanceType>(left_bbox[cutfeat].high);
+        node->node_type.sub.divhigh = static_cast<DistanceType>(right_bbox[cutfeat].low);
 
         const Dimension dims = static_cast<Dimension>(veclen(obj));
         for (Dimension i = 0; i < dims; ++i)
@@ -1544,30 +1544,35 @@ class KDTreeBaseClass
         const Dimension dims = static_cast<Dimension>(veclen(obj));
         const auto      EPS  = static_cast<DistanceType>(0.00001);
 
+        // Spans, spreads and the split value below are all computed in
+        // DistanceType, which detail::checked_distance_type guarantees to be
+        // signed: a difference of two ElementType coordinates wraps around for
+        // unsigned types, and overflows for signed ones as soon as the data
+        // spans most of the range of a narrow integer type.
+
         // Pre-compute max_span once
-        ElementType max_span = bbox[0].high - bbox[0].low;
+        DistanceType max_span = detail::diff_as<DistanceType>(bbox[0].high, bbox[0].low);
         for (Dimension i = 1; i < dims; ++i)
         {
-            ElementType span = bbox[i].high - bbox[i].low;
+            const DistanceType span = detail::diff_as<DistanceType>(bbox[i].high, bbox[i].low);
             if (span > max_span) max_span = span;
         }
 
         // Two-pass: first find max_span (done above), then scan candidate dims
         // inline — no heap allocation for a candidates vector.
-        // Note: `max_spread` must not be seeded with a negative sentinel:
-        // ElementType may be unsigned (e.g. uint8_t), where -1 wraps around to
-        // the largest representable value and no dimension is ever selected,
-        // leaving a degenerate cut that breaks the partition below. A flag for
-        // the first candidate keeps this selection type-agnostic.
-        cutfeat                      = 0;
-        bool              first      = true;
-        ElementType       max_spread = 0;
-        ElementType       min_elem = 0, max_elem = 0;
-        const ElementType threshold = static_cast<ElementType>((1 - EPS) * max_span);
+        // Note: `max_spread` must not be seeded with a negative sentinel, which
+        // wraps around for unsigned types and is not even constructible for a
+        // user-defined scalar DistanceType. A flag for the first candidate keeps
+        // this selection type-agnostic.
+        cutfeat                       = 0;
+        bool               first      = true;
+        DistanceType       max_spread = DistanceType();
+        ElementType        min_elem = 0, max_elem = 0;
+        const DistanceType threshold = (1 - EPS) * max_span;
 
         for (Dimension dim = 0; dim < dims; ++dim)
         {
-            if (bbox[dim].high - bbox[dim].low < threshold) continue;
+            if (detail::diff_as<DistanceType>(bbox[dim].high, bbox[dim].low) < threshold) continue;
 
             ElementType local_min = dataset_get(obj, vAcc_[ind], dim);
             ElementType local_max = local_min;
@@ -1594,7 +1599,7 @@ class KDTreeBaseClass
                 local_max       = std::max(local_max, val);
             }
 
-            const ElementType spread = local_max - local_min;
+            const DistanceType spread = detail::diff_as<DistanceType>(local_max, local_min);
             if (first || spread > max_spread)
             {
                 first      = false;
@@ -1607,12 +1612,11 @@ class KDTreeBaseClass
 
         // Median-of-three for better balance. The midpoint is computed as
         // `low + (high - low) / 2` rather than `(low + high) / 2`, since the
-        // latter overflows whenever ElementType is a wide integer type
-        // (e.g. two large uint32_t coordinates wrap around when added).
-        const ElementType lo = bbox[cutfeat].low;
-        const ElementType hi = bbox[cutfeat].high;
+        // latter overflows as soon as both coordinates are large.
+        const DistanceType lo = static_cast<DistanceType>(bbox[cutfeat].low);
+        const DistanceType hi = static_cast<DistanceType>(bbox[cutfeat].high);
 
-        DistanceType split_val = static_cast<DistanceType>(lo + (hi - lo) / 2);
+        DistanceType split_val = lo + (hi - lo) / 2;
         if (split_val < static_cast<DistanceType>(min_elem))
             split_val = static_cast<DistanceType>(min_elem);
         if (split_val > static_cast<DistanceType>(max_elem))
@@ -1650,7 +1654,11 @@ class KDTreeBaseClass
 
         while (mid < right)
         {
-            const ElementType val = dataset_get(obj, vAcc_[ind + mid], cutfeat);
+            // Compared in DistanceType, like every other coordinate-vs-cutval
+            // comparison, so that a wide unsigned ElementType is not converted
+            // the other way around.
+            const DistanceType val =
+                static_cast<DistanceType>(dataset_get(obj, vAcc_[ind + mid], cutfeat));
 
             if (val < cutval)
             {

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -245,6 +245,41 @@ struct ResultItem
 
 namespace detail
 {
+/** Validates the `_DistanceType` of a distance adaptor.
+ *
+ *  The kd-tree build and search algorithms subtract coordinates and compare
+ *  the result against negative sentinels, so distances must be representable
+ *  as negative values. An unsigned `DistanceType` makes those subtractions
+ *  wrap around modulo 2^N, which yields wrong neighbors and can crash the
+ *  build (see the split logic in KDTreeBaseClass::middleSplit_).
+ *
+ *  Non-arithmetic (user-defined) scalar types are accepted as-is, since
+ *  std::is_signed<> says nothing useful about them.
+ */
+template <typename DistanceType>
+struct checked_distance_type
+{
+    static_assert(
+        !std::is_arithmetic<DistanceType>::value || std::is_signed<DistanceType>::value,
+        "nanoflann: _DistanceType must be signed. If ElementType is unsigned "
+        "(e.g. uint8_t), pass an explicit signed _DistanceType wide enough for "
+        "the squared distances of your coordinate range, for example: "
+        "L2_Simple_Adaptor<uint8_t, MyCloud, int32_t>.");
+
+    using type = DistanceType;
+};
+
+/** Computes `a - b` in \a ResultType instead of in the operands' own type.
+ *  Required for unsigned element types, whose native subtraction wraps around
+ *  modulo 2^N rather than becoming negative. For every type at least as wide
+ *  as the operands (i.e. any sane DistanceType) the result is identical to
+ *  the plain `a - b` expression. */
+template <typename ResultType, typename U, typename V>
+inline ResultType diff_as(const U a, const V b)
+{
+    return static_cast<ResultType>(a) - static_cast<ResultType>(b);
+}
+
 /** Insert (dist, index) into a sorted result buffer (dists, indices) of the
  *  given capacity, keeping ascending distance order.  Shared by KNNResultSet
  *  and RKNNResultSet, which are otherwise byte-for-byte identical.
@@ -544,7 +579,10 @@ struct Metric
  *
  * \tparam T Type of the elements (e.g. double, float, uint8_t)
  * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed)
+ * \tparam _DistanceType Type of distance variables (must be signed). It
+ * defaults to \a T, so for an unsigned \a T (e.g. uint8_t) it must be given
+ * explicitly, wide enough for the distances of the actual coordinate range,
+ * e.g. `L2_Simple_Adaptor<uint8_t, MyCloud, int32_t>`.
  * \tparam IndexType Type of the arguments with which the data can be
  * accessed (e.g. float, double, int64_t, T*)
  */
@@ -552,7 +590,7 @@ template <class T, class DataSource, typename _DistanceType = T, typename IndexT
 struct L1_Adaptor
 {
     using ElementType  = T;
-    using DistanceType = _DistanceType;
+    using DistanceType = typename detail::checked_distance_type<_DistanceType>::type;
 
     const DataSource& data_source;
 
@@ -567,10 +605,14 @@ struct L1_Adaptor
 
         for (d = 0; d < multof4; d += 4)
         {
-            const DistanceType diff0 = std::abs(a[d + 0] - data_source.kdtree_get_pt(b_idx, d + 0));
-            const DistanceType diff1 = std::abs(a[d + 1] - data_source.kdtree_get_pt(b_idx, d + 1));
-            const DistanceType diff2 = std::abs(a[d + 2] - data_source.kdtree_get_pt(b_idx, d + 2));
-            const DistanceType diff3 = std::abs(a[d + 3] - data_source.kdtree_get_pt(b_idx, d + 3));
+            const DistanceType diff0 = std::abs(
+                detail::diff_as<DistanceType>(a[d + 0], data_source.kdtree_get_pt(b_idx, d + 0)));
+            const DistanceType diff1 = std::abs(
+                detail::diff_as<DistanceType>(a[d + 1], data_source.kdtree_get_pt(b_idx, d + 1)));
+            const DistanceType diff2 = std::abs(
+                detail::diff_as<DistanceType>(a[d + 2], data_source.kdtree_get_pt(b_idx, d + 2)));
+            const DistanceType diff3 = std::abs(
+                detail::diff_as<DistanceType>(a[d + 3], data_source.kdtree_get_pt(b_idx, d + 3)));
             /* Parentheses break dependency chain: */
             result += (diff0 + diff1) + (diff2 + diff3);
         }
@@ -579,13 +621,16 @@ struct L1_Adaptor
         switch (size - multof4)
         {
             case 3:
-                result += std::abs(a[d + 2] - data_source.kdtree_get_pt(b_idx, d + 2));
+                result += std::abs(detail::diff_as<DistanceType>(
+                    a[d + 2], data_source.kdtree_get_pt(b_idx, d + 2)));
                 NANOFLANN_FALLTHROUGH;
             case 2:
-                result += std::abs(a[d + 1] - data_source.kdtree_get_pt(b_idx, d + 1));
+                result += std::abs(detail::diff_as<DistanceType>(
+                    a[d + 1], data_source.kdtree_get_pt(b_idx, d + 1)));
                 NANOFLANN_FALLTHROUGH;
             case 1:
-                result += std::abs(a[d + 0] - data_source.kdtree_get_pt(b_idx, d + 0));
+                result += std::abs(detail::diff_as<DistanceType>(
+                    a[d + 0], data_source.kdtree_get_pt(b_idx, d + 0)));
                 NANOFLANN_FALLTHROUGH;
             case 0:
                 break;
@@ -596,7 +641,7 @@ struct L1_Adaptor
     template <typename U, typename V>
     inline DistanceType accum_dist(const U a, const V b, const size_t) const
     {
-        return std::abs(a - b);
+        return std::abs(detail::diff_as<DistanceType>(a, b));
     }
 };
 
@@ -606,7 +651,10 @@ struct L1_Adaptor
  *
  * \tparam T Type of the elements (e.g. double, float, uint8_t)
  * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed)
+ * \tparam _DistanceType Type of distance variables (must be signed). It
+ * defaults to \a T, so for an unsigned \a T (e.g. uint8_t) it must be given
+ * explicitly, wide enough for the distances of the actual coordinate range,
+ * e.g. `L2_Simple_Adaptor<uint8_t, MyCloud, int32_t>`.
  * \tparam IndexType Type of the arguments with which the data can be
  * accessed (e.g. float, double, int64_t, T*)
  */
@@ -614,7 +662,7 @@ template <class T, class DataSource, typename _DistanceType = T, typename IndexT
 struct L2_Adaptor
 {
     using ElementType  = T;
-    using DistanceType = _DistanceType;
+    using DistanceType = typename detail::checked_distance_type<_DistanceType>::type;
 
     const DataSource& data_source;
 
@@ -629,10 +677,14 @@ struct L2_Adaptor
 
         for (d = 0; d < multof4; d += 4)
         {
-            const DistanceType diff0 = a[d + 0] - data_source.kdtree_get_pt(b_idx, d + 0);
-            const DistanceType diff1 = a[d + 1] - data_source.kdtree_get_pt(b_idx, d + 1);
-            const DistanceType diff2 = a[d + 2] - data_source.kdtree_get_pt(b_idx, d + 2);
-            const DistanceType diff3 = a[d + 3] - data_source.kdtree_get_pt(b_idx, d + 3);
+            const DistanceType diff0 =
+                detail::diff_as<DistanceType>(a[d + 0], data_source.kdtree_get_pt(b_idx, d + 0));
+            const DistanceType diff1 =
+                detail::diff_as<DistanceType>(a[d + 1], data_source.kdtree_get_pt(b_idx, d + 1));
+            const DistanceType diff2 =
+                detail::diff_as<DistanceType>(a[d + 2], data_source.kdtree_get_pt(b_idx, d + 2));
+            const DistanceType diff3 =
+                detail::diff_as<DistanceType>(a[d + 3], data_source.kdtree_get_pt(b_idx, d + 3));
             /* Parentheses break dependency chain: */
             result += (diff0 * diff0 + diff1 * diff1) + (diff2 * diff2 + diff3 * diff3);
         }
@@ -642,15 +694,18 @@ struct L2_Adaptor
         switch (size - multof4)
         {
             case 3:
-                diff = a[d + 2] - data_source.kdtree_get_pt(b_idx, d + 2);
+                diff = detail::diff_as<DistanceType>(
+                    a[d + 2], data_source.kdtree_get_pt(b_idx, d + 2));
                 result += diff * diff;
                 NANOFLANN_FALLTHROUGH;
             case 2:
-                diff = a[d + 1] - data_source.kdtree_get_pt(b_idx, d + 1);
+                diff = detail::diff_as<DistanceType>(
+                    a[d + 1], data_source.kdtree_get_pt(b_idx, d + 1));
                 result += diff * diff;
                 NANOFLANN_FALLTHROUGH;
             case 1:
-                diff = a[d + 0] - data_source.kdtree_get_pt(b_idx, d + 0);
+                diff = detail::diff_as<DistanceType>(
+                    a[d + 0], data_source.kdtree_get_pt(b_idx, d + 0));
                 result += diff * diff;
                 NANOFLANN_FALLTHROUGH;
             case 0:
@@ -662,7 +717,7 @@ struct L2_Adaptor
     template <typename U, typename V>
     inline DistanceType accum_dist(const U a, const V b, const size_t) const
     {
-        auto diff = a - b;
+        const DistanceType diff = detail::diff_as<DistanceType>(a, b);
         return diff * diff;
     }
 };
@@ -673,7 +728,10 @@ struct L2_Adaptor
  *
  * \tparam T Type of the elements (e.g. double, float, uint8_t)
  * \tparam DataSource Source of the data, i.e. where the vectors are stored
- * \tparam _DistanceType Type of distance variables (must be signed)
+ * \tparam _DistanceType Type of distance variables (must be signed). It
+ * defaults to \a T, so for an unsigned \a T (e.g. uint8_t) it must be given
+ * explicitly, wide enough for the distances of the actual coordinate range,
+ * e.g. `L2_Simple_Adaptor<uint8_t, MyCloud, int32_t>`.
  * \tparam IndexType Type of the arguments with which the data can be
  * accessed (e.g. float, double, int64_t, T*)
  */
@@ -681,7 +739,7 @@ template <class T, class DataSource, typename _DistanceType = T, typename IndexT
 struct L2_Simple_Adaptor
 {
     using ElementType  = T;
-    using DistanceType = _DistanceType;
+    using DistanceType = typename detail::checked_distance_type<_DistanceType>::type;
 
     const DataSource& data_source;
 
@@ -692,7 +750,8 @@ struct L2_Simple_Adaptor
         DistanceType result = DistanceType();
         for (size_t i = 0; i < size; ++i)
         {
-            const DistanceType diff = a[i] - data_source.kdtree_get_pt(b_idx, i);
+            const DistanceType diff =
+                detail::diff_as<DistanceType>(a[i], data_source.kdtree_get_pt(b_idx, i));
             result += diff * diff;
         }
         return result;
@@ -701,7 +760,7 @@ struct L2_Simple_Adaptor
     template <typename U, typename V>
     inline DistanceType accum_dist(const U a, const V b, const size_t) const
     {
-        auto diff = a - b;
+        const DistanceType diff = detail::diff_as<DistanceType>(a, b);
         return diff * diff;
     }
 };
@@ -720,7 +779,7 @@ template <class T, class DataSource, typename _DistanceType = T, typename IndexT
 struct SO2_Adaptor
 {
     using ElementType  = T;
-    using DistanceType = _DistanceType;
+    using DistanceType = typename detail::checked_distance_type<_DistanceType>::type;
 
     const DataSource& data_source;
 
@@ -763,7 +822,7 @@ template <class T, class DataSource, typename _DistanceType = T, typename IndexT
 struct SO3_Adaptor
 {
     using ElementType  = T;
-    using DistanceType = _DistanceType;
+    using DistanceType = typename detail::checked_distance_type<_DistanceType>::type;
 
     L2_Simple_Adaptor<T, DataSource, DistanceType, IndexType> distance_L2_Simple;
 
@@ -1394,12 +1453,12 @@ class KDTreeBaseClass
 
         /* Recurse on left */
         BoundingBox left_bbox(bbox);
-        left_bbox[cutfeat].high = cutval;
+        left_bbox[cutfeat].high = static_cast<ElementType>(cutval);
         node->child1            = this->divideTree(obj, left, left + idx, left_bbox);
 
         /* Recurse on right */
         BoundingBox right_bbox(bbox);
-        right_bbox[cutfeat].low = cutval;
+        right_bbox[cutfeat].low = static_cast<ElementType>(cutval);
         node->child2            = this->divideTree(obj, left + idx, right, right_bbox);
 
         finalizeSplitNode(obj, node, cutfeat, left_bbox, right_bbox, bbox);
@@ -1437,7 +1496,7 @@ class KDTreeBaseClass
         /* Recurse on right concurrently, if possible */
 
         BoundingBox right_bbox(bbox);
-        right_bbox[cutfeat].low = cutval;
+        right_bbox[cutfeat].low = static_cast<ElementType>(cutval);
         if (++thread_count < n_thread_build_)
         {
             /* Concurrent thread for right recursion */
@@ -1454,7 +1513,7 @@ class KDTreeBaseClass
         /* Recurse on left in this thread */
 
         BoundingBox left_bbox(bbox);
-        left_bbox[cutfeat].high = cutval;
+        left_bbox[cutfeat].high = static_cast<ElementType>(cutval);
         node->child1 =
             this->divideTreeConcurrent(obj, left, left + idx, left_bbox, thread_count, mutex);
 
@@ -1495,10 +1554,16 @@ class KDTreeBaseClass
 
         // Two-pass: first find max_span (done above), then scan candidate dims
         // inline — no heap allocation for a candidates vector.
+        // Note: `max_spread` must not be seeded with a negative sentinel:
+        // ElementType may be unsigned (e.g. uint8_t), where -1 wraps around to
+        // the largest representable value and no dimension is ever selected,
+        // leaving a degenerate cut that breaks the partition below. A flag for
+        // the first candidate keeps this selection type-agnostic.
         cutfeat                      = 0;
-        ElementType       max_spread = -1;
+        bool              first      = true;
+        ElementType       max_spread = 0;
         ElementType       min_elem = 0, max_elem = 0;
-        const ElementType threshold = (1 - EPS) * max_span;
+        const ElementType threshold = static_cast<ElementType>((1 - EPS) * max_span);
 
         for (Dimension dim = 0; dim < dims; ++dim)
         {
@@ -1529,9 +1594,10 @@ class KDTreeBaseClass
                 local_max       = std::max(local_max, val);
             }
 
-            ElementType spread = local_max - local_min;
-            if (spread > max_spread)
+            const ElementType spread = local_max - local_min;
+            if (first || spread > max_spread)
             {
+                first      = false;
                 cutfeat    = dim;
                 max_spread = spread;
                 min_elem   = local_min;
@@ -1539,10 +1605,18 @@ class KDTreeBaseClass
             }
         }
 
-        // Median-of-three for better balance
-        DistanceType split_val = (bbox[cutfeat].low + bbox[cutfeat].high) / 2;
-        if (split_val < min_elem) split_val = min_elem;
-        if (split_val > max_elem) split_val = max_elem;
+        // Median-of-three for better balance. The midpoint is computed as
+        // `low + (high - low) / 2` rather than `(low + high) / 2`, since the
+        // latter overflows whenever ElementType is a wide integer type
+        // (e.g. two large uint32_t coordinates wrap around when added).
+        const ElementType lo = bbox[cutfeat].low;
+        const ElementType hi = bbox[cutfeat].high;
+
+        DistanceType split_val = static_cast<DistanceType>(lo + (hi - lo) / 2);
+        if (split_val < static_cast<DistanceType>(min_elem))
+            split_val = static_cast<DistanceType>(min_elem);
+        if (split_val > static_cast<DistanceType>(max_elem))
+            split_val = static_cast<DistanceType>(max_elem);
 
         cutval = split_val;
 
@@ -1566,14 +1640,17 @@ class KDTreeBaseClass
         const Derived& obj, const Offset ind, const Size count, const Dimension cutfeat,
         const DistanceType& cutval, Offset& lim1, Offset& lim2)
     {
-        // Dutch National Flag algorithm for three-way partitioning
+        // Dutch National Flag algorithm for three-way partitioning, over the
+        // half-open range [0, count). Offset is unsigned, so a closed-range
+        // `[0, count-1]` variant underflows to SIZE_MAX if every element ends
+        // up above cutval.
         Offset left  = 0;
         Offset mid   = 0;
-        Offset right = count - 1;
+        Offset right = count;
 
-        while (mid <= right)
+        while (mid < right)
         {
-            ElementType val = dataset_get(obj, vAcc_[ind + mid], cutfeat);
+            const ElementType val = dataset_get(obj, vAcc_[ind + mid], cutfeat);
 
             if (val < cutval)
             {
@@ -1583,8 +1660,9 @@ class KDTreeBaseClass
             }
             else if (val > cutval)
             {
-                std::swap(vAcc_[ind + mid], vAcc_[ind + right]);
+                // right > mid >= 0, so decrementing it cannot underflow
                 right--;
+                std::swap(vAcc_[ind + mid], vAcc_[ind + right]);
             }
             else
             {
@@ -3757,9 +3835,11 @@ class KDTreeSingleIndexIncrementalAdaptor
         if (lo >= hi) return nullptr;
         const Dimension dims = static_cast<Dimension>(this->veclen(*this));
 
-        // Widest-spread axis over buf[lo,hi).
+        // Widest-spread axis over buf[lo,hi). As in middleSplit_, `bestSpan`
+        // cannot use a negative sentinel, since ElementType may be unsigned.
         Dimension   axis     = static_cast<Dimension>(depth % dims);
-        ElementType bestSpan = -1;
+        bool        first    = true;
+        ElementType bestSpan = 0;
         for (Dimension d = 0; d < dims; ++d)
         {
             ElementType mn = pt(buf[lo], d), mx = mn;
@@ -3770,8 +3850,9 @@ class KDTreeSingleIndexIncrementalAdaptor
                 if (v > mx) mx = v;
             }
             const ElementType span = mx - mn;
-            if (span > bestSpan)
+            if (first || span > bestSpan)
             {
+                first    = false;
                 bestSpan = span;
                 axis     = d;
             }

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -891,3 +891,90 @@ inline bool inc_in_box(const inc_cloud_t& c, uint32_t i, const double lo[3], con
     return c.pts[i].x >= lo[0] && c.pts[i].x <= hi[0] && c.pts[i].y >= lo[1] &&
            c.pts[i].y <= hi[1] && c.pts[i].z >= lo[2] && c.pts[i].z <= hi[2];
 }
+
+// ---------------------------------------------------------------------------
+// Helpers for integral (in particular unsigned) ElementTypes.
+//
+// std::rand() cannot cover the range of the wider types, so these use a
+// deterministic mt19937_64 to keep failures reproducible.
+// ---------------------------------------------------------------------------
+
+// Fill a 3D PointCloud<T> with coordinates uniformly drawn from [0, max_coord].
+template <typename T>
+void generateRandomIntegralPointCloud(
+    PointCloud<T>& pc, const size_t N, const T max_coord, const uint64_t seed)
+{
+    std::mt19937_64                         rng(seed);
+    std::uniform_int_distribution<uint64_t> dis(0, static_cast<uint64_t>(max_coord));
+
+    pc.pts.resize(N);
+    for (auto& p : pc.pts)
+    {
+        p.x = static_cast<T>(dis(rng));
+        p.y = static_cast<T>(dis(rng));
+        p.z = static_cast<T>(dis(rng));
+    }
+}
+
+// Builds a kd-tree over an integral ElementType and compares a knn query
+// against an exact double brute force. IsL1 selects the |a-b| accumulation
+// instead of (a-b)^2.
+template <
+    typename ElementType, typename DistanceType,
+    template <class, class, class, class> class Adaptor, bool IsL1>
+void integral_kd_vs_bruteforce_test(
+    const size_t N, const size_t numToSearch, const ElementType max_coord, const uint64_t seed)
+{
+    using cloud_t   = PointCloud<ElementType>;
+    using adaptor_t = Adaptor<ElementType, cloud_t, DistanceType, size_t>;
+    using kdtree_t  = KDTreeSingleIndexAdaptor<adaptor_t, cloud_t, 3>;
+
+    cloud_t cloud;
+    generateRandomIntegralPointCloud(cloud, N, max_coord, seed);
+
+    kdtree_t index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10));
+
+    // Query point, drawn from the same range as the cloud:
+    std::mt19937_64                         rng(seed + 1);
+    std::uniform_int_distribution<uint64_t> dis(0, static_cast<uint64_t>(max_coord));
+    const ElementType                       query_pt[3] = {
+                              static_cast<ElementType>(dis(rng)), static_cast<ElementType>(dis(rng)),
+                              static_cast<ElementType>(dis(rng))};
+
+    std::vector<size_t>       ret_indexes(numToSearch);
+    std::vector<DistanceType> out_dists(numToSearch);
+
+    nanoflann::KNNResultSet<DistanceType> resultSet(numToSearch);
+    resultSet.init(&ret_indexes[0], &out_dists[0]);
+    index.findNeighbors(resultSet, &query_pt[0]);
+
+    ASSERT_EQ(resultSet.size(), numToSearch);
+
+    // Exact brute force, in double:
+    // Note the explicit return type: C++11 only deduces it for single-return
+    // lambda bodies.
+    const auto bf_dist = [&](const size_t i) -> double
+    {
+        const double dx = static_cast<double>(query_pt[0]) - static_cast<double>(cloud.pts[i].x);
+        const double dy = static_cast<double>(query_pt[1]) - static_cast<double>(cloud.pts[i].y);
+        const double dz = static_cast<double>(query_pt[2]) - static_cast<double>(cloud.pts[i].z);
+        if (IsL1) return std::abs(dx) + std::abs(dy) + std::abs(dz);
+        return dx * dx + dy * dy + dz * dz;
+    };
+
+    std::vector<double> bf;
+    bf.reserve(N);
+    for (size_t i = 0; i < N; i++) bf.push_back(bf_dist(i));
+    std::sort(bf.begin(), bf.end());
+
+    for (size_t i = 0; i < numToSearch; i++)
+    {
+        // Relative tolerance: with wide integral coordinates the squared
+        // distances exceed the exactly-representable range of double.
+        const double tol = std::max(1e-3, std::abs(bf[i]) * 1e-9);
+        EXPECT_NEAR(bf[i], static_cast<double>(out_dists[i]), tol) << " i=" << i;
+        // The reported index must really be at the reported distance (ties
+        // may be returned in a different order than the brute-force one):
+        EXPECT_NEAR(bf_dist(ret_indexes[i]), static_cast<double>(out_dists[i]), tol) << " i=" << i;
+    }
+}

--- a/tests/test_kdtree_basic.cpp
+++ b/tests/test_kdtree_basic.cpp
@@ -249,3 +249,131 @@ TEST(kdtree, same_points)
 
     kdtree_t idx(3 /*dim*/, cloud);
 }
+
+// ---------------------------------------------------------------------------
+// Unsigned / integral ElementType.
+//
+// Building an index over an unsigned ElementType used to abort with a
+// heap-buffer-overflow inside planeSplit(): the spread sentinel in
+// middleSplit_() wrapped around to the largest representable value, no cut
+// dimension was ever selected, and the resulting degenerate cut sent every
+// point to the same side of the partition.
+// ---------------------------------------------------------------------------
+
+TEST(kdtree, unsigned_vs_bruteforce)
+{
+    for (uint64_t seed = 0; seed < 20; seed++)
+    {
+        integral_kd_vs_bruteforce_test<uint8_t, int32_t, L2_Simple_Adaptor, false>(
+            200, 5, 255, seed);
+        integral_kd_vs_bruteforce_test<uint8_t, int32_t, L2_Adaptor, false>(200, 5, 255, seed);
+        integral_kd_vs_bruteforce_test<uint8_t, int32_t, L1_Adaptor, true>(200, 5, 255, seed);
+
+        // A floating-point DistanceType is equally valid:
+        integral_kd_vs_bruteforce_test<uint8_t, float, L2_Simple_Adaptor, false>(200, 5, 255, seed);
+
+        integral_kd_vs_bruteforce_test<uint16_t, int64_t, L2_Simple_Adaptor, false>(
+            300, 5, 65535, seed);
+
+        // Full uint32_t range: exercises the midpoint computation in
+        // middleSplit_(), which overflows if done in ElementType.
+        integral_kd_vs_bruteforce_test<uint32_t, double, L2_Simple_Adaptor, false>(
+            300, 5, 4294967295u, seed);
+    }
+}
+
+TEST(kdtree, unsigned_radius_search)
+{
+    using cloud_t   = PointCloud<uint8_t>;
+    using adaptor_t = L2_Simple_Adaptor<uint8_t, cloud_t, int32_t>;
+    using kdtree_t  = KDTreeSingleIndexAdaptor<adaptor_t, cloud_t, 3 /* dim */>;
+
+    cloud_t cloud;
+    generateRandomIntegralPointCloud<uint8_t>(cloud, 500, 255, 42);
+
+    kdtree_t index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10));
+
+    const uint8_t query_pt[3] = {100, 120, 140};
+    const int32_t radius      = 10000;
+
+    std::vector<nanoflann::ResultItem<typename kdtree_t::IndexType, int32_t>> matches;
+    const size_t nFound = index.radiusSearch(&query_pt[0], radius, matches);
+
+    // RadiusResultSet::addPoint keeps a point only if dist < radius (strict):
+    size_t bf_count = 0;
+    for (const auto& p : cloud.pts)
+    {
+        const int32_t dx = int32_t(query_pt[0]) - int32_t(p.x);
+        const int32_t dy = int32_t(query_pt[1]) - int32_t(p.y);
+        const int32_t dz = int32_t(query_pt[2]) - int32_t(p.z);
+        if (dx * dx + dy * dy + dz * dz < radius) bf_count++;
+    }
+
+    EXPECT_GT(bf_count, 0u);
+    EXPECT_EQ(nFound, bf_count);
+    EXPECT_EQ(matches.size(), bf_count);
+}
+
+TEST(kdtree, unsigned_same_points)
+{
+    // Degenerate case: every value equals the cut value, so the partition
+    // takes only the "equal" branch and must still terminate.
+    using cloud_t   = PointCloud<uint8_t>;
+    using adaptor_t = L2_Simple_Adaptor<uint8_t, cloud_t, int32_t>;
+    using kdtree_t  = KDTreeSingleIndexAdaptor<adaptor_t, cloud_t, 3 /* dim */>;
+
+    cloud_t cloud;
+    cloud.pts.resize(16);
+    for (auto& p : cloud.pts)
+    {
+        p.x = 200;
+        p.y = 0;
+        p.z = 255;
+    }
+
+    kdtree_t index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(4));
+
+    const uint8_t query_pt[3] = {200, 0, 255};
+    size_t        ret_index   = 0;
+    int32_t       out_dist    = -1;
+
+    nanoflann::KNNResultSet<int32_t> resultSet(1);
+    resultSet.init(&ret_index, &out_dist);
+    ASSERT_TRUE(index.findNeighbors(resultSet, &query_pt[0]));
+    EXPECT_EQ(out_dist, 0);
+}
+
+TEST(kdtree, unsigned_incremental_index)
+{
+    // The incremental index selects its cut axis with the same "widest
+    // spread" logic, which has to stay unsigned-safe too.
+    using cloud_t   = PointCloud<uint8_t>;
+    using adaptor_t = L2_Simple_Adaptor<uint8_t, cloud_t, int32_t>;
+    using kdtree_t  = nanoflann::KDTreeSingleIndexIncrementalAdaptor<adaptor_t, cloud_t, 3>;
+
+    cloud_t cloud;
+    generateRandomIntegralPointCloud<uint8_t>(cloud, 300, 255, 7);
+
+    kdtree_t index(3 /*dim*/, cloud);
+    index.addPoints(0, static_cast<kdtree_t::IndexType>(cloud.pts.size() - 1));
+
+    const uint8_t query_pt[3] = {30, 60, 90};
+
+    size_t  ret_index = 0;
+    int32_t out_dist  = -1;
+
+    nanoflann::KNNResultSet<int32_t> resultSet(1);
+    resultSet.init(&ret_index, &out_dist);
+    ASSERT_TRUE(index.findNeighbors(resultSet, &query_pt[0]));
+
+    int32_t bf_best = std::numeric_limits<int32_t>::max();
+    for (const auto& p : cloud.pts)
+    {
+        const int32_t dx = int32_t(query_pt[0]) - int32_t(p.x);
+        const int32_t dy = int32_t(query_pt[1]) - int32_t(p.y);
+        const int32_t dz = int32_t(query_pt[2]) - int32_t(p.z);
+        bf_best          = std::min(bf_best, dx * dx + dy * dy + dz * dz);
+    }
+
+    EXPECT_EQ(out_dist, bf_best);
+}

--- a/tests/test_kdtree_basic.cpp
+++ b/tests/test_kdtree_basic.cpp
@@ -275,11 +275,63 @@ TEST(kdtree, unsigned_vs_bruteforce)
         integral_kd_vs_bruteforce_test<uint16_t, int64_t, L2_Simple_Adaptor, false>(
             300, 5, 65535, seed);
 
-        // Full uint32_t range: exercises the midpoint computation in
-        // middleSplit_(), which overflows if done in ElementType.
+        // Full uint32_t and uint64_t ranges: exercise the span and midpoint
+        // computations in middleSplit_(), which overflow if done in
+        // ElementType, and the metric subtractions, which wrap around.
         integral_kd_vs_bruteforce_test<uint32_t, double, L2_Simple_Adaptor, false>(
-            300, 5, 4294967295u, seed);
+            300, 5, std::numeric_limits<uint32_t>::max(), seed);
+        integral_kd_vs_bruteforce_test<uint64_t, double, L2_Simple_Adaptor, false>(
+            300, 5, std::numeric_limits<uint64_t>::max(), seed);
     }
+}
+
+TEST(kdtree, signed_extreme_range)
+{
+    // Coordinates spanning nearly the whole int32_t range: computing spans,
+    // spreads or the split midpoint in ElementType overflows (UB), so they
+    // must be evaluated in the wider DistanceType.
+    using cloud_t   = PointCloud<int32_t>;
+    using adaptor_t = L2_Simple_Adaptor<int32_t, cloud_t, double>;
+    using kdtree_t  = KDTreeSingleIndexAdaptor<adaptor_t, cloud_t, 3 /* dim */>;
+
+    const int32_t lo = std::numeric_limits<int32_t>::min();
+    const int32_t hi = std::numeric_limits<int32_t>::max();
+
+    std::mt19937_64                        rng(99);
+    std::uniform_int_distribution<int32_t> dis(lo, hi);
+
+    cloud_t cloud;
+    cloud.pts.resize(400);
+    for (auto& p : cloud.pts)
+    {
+        p.x = dis(rng);
+        p.y = dis(rng);
+        p.z = dis(rng);
+    }
+    // Force the bounding box to actually span the full range:
+    cloud.pts[0] = {lo, lo, lo};
+    cloud.pts[1] = {hi, hi, hi};
+
+    kdtree_t index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(10));
+
+    const int32_t query_pt[3] = {0, 1000, -1000};
+    size_t        ret_index   = 0;
+    double        out_dist    = -1;
+
+    nanoflann::KNNResultSet<double> resultSet(1);
+    resultSet.init(&ret_index, &out_dist);
+    ASSERT_TRUE(index.findNeighbors(resultSet, &query_pt[0]));
+
+    double bf_best = std::numeric_limits<double>::max();
+    for (const auto& p : cloud.pts)
+    {
+        const double dx = double(query_pt[0]) - double(p.x);
+        const double dy = double(query_pt[1]) - double(p.y);
+        const double dz = double(query_pt[2]) - double(p.z);
+        bf_best         = std::min(bf_best, dx * dx + dy * dy + dz * dz);
+    }
+
+    EXPECT_EQ(out_dist, bf_best);
 }
 
 TEST(kdtree, unsigned_radius_search)
@@ -299,19 +351,31 @@ TEST(kdtree, unsigned_radius_search)
     std::vector<nanoflann::ResultItem<typename kdtree_t::IndexType, int32_t>> matches;
     const size_t nFound = index.radiusSearch(&query_pt[0], radius, matches);
 
-    // RadiusResultSet::addPoint keeps a point only if dist < radius (strict):
-    size_t bf_count = 0;
-    for (const auto& p : cloud.pts)
+    const auto sq_dist = [&](const size_t i) -> int32_t
     {
-        const int32_t dx = int32_t(query_pt[0]) - int32_t(p.x);
-        const int32_t dy = int32_t(query_pt[1]) - int32_t(p.y);
-        const int32_t dz = int32_t(query_pt[2]) - int32_t(p.z);
-        if (dx * dx + dy * dy + dz * dz < radius) bf_count++;
+        const int32_t dx = int32_t(query_pt[0]) - int32_t(cloud.pts[i].x);
+        const int32_t dy = int32_t(query_pt[1]) - int32_t(cloud.pts[i].y);
+        const int32_t dz = int32_t(query_pt[2]) - int32_t(cloud.pts[i].z);
+        return dx * dx + dy * dy + dz * dz;
+    };
+
+    // RadiusResultSet::addPoint keeps a point only if dist < radius (strict):
+    std::set<kdtree_t::IndexType> expected;
+    for (size_t i = 0; i < cloud.pts.size(); i++)
+        if (sq_dist(i) < radius) expected.insert(static_cast<kdtree_t::IndexType>(i));
+
+    // Compare the actual membership, not just the count. The results are not
+    // requested sorted, so compare them as a set:
+    std::set<kdtree_t::IndexType> found;
+    for (const auto& m : matches)
+    {
+        found.insert(m.first);
+        EXPECT_EQ(m.second, sq_dist(m.first));
     }
 
-    EXPECT_GT(bf_count, 0u);
-    EXPECT_EQ(nFound, bf_count);
-    EXPECT_EQ(matches.size(), bf_count);
+    EXPECT_GT(expected.size(), 0u);
+    EXPECT_EQ(nFound, expected.size());
+    EXPECT_TRUE(found == expected);
 }
 
 TEST(kdtree, unsigned_same_points)


### PR DESCRIPTION
Alternative, minimal take on the bug reported in #314 by @TomRoyls. Thanks for
the report and for digging into the root cause there — this PR keeps the same
diagnosis but takes a smaller, fully backwards-compatible route. @TomRoyls, it
would be great if you could check it against your use case.

## The bug

Building an index over an unsigned `ElementType` aborts with a
heap-buffer-overflow inside `planeSplit()`. Reproduced under ASan on `master`:

```
ERROR: AddressSanitizer: heap-buffer-overflow
    #0 std::swap<unsigned int>(...)
    #1 nanoflann::KDTreeBaseClass<...>::planeSplit(...)  nanoflann.hpp:1586
    #2 nanoflann::KDTreeBaseClass<...>::middleSplit_(...) nanoflann.hpp:1551
```

Worth highlighting: this happens **even when a signed `_DistanceType` is passed
explicitly**, i.e. with `L2_Simple_Adaptor<uint8_t, Cloud, float>`, which is
what the documentation already tells users to do. So the root cause is not the
unsigned distance type:

`middleSplit_()` seeds the widest-spread search with `ElementType max_spread = -1`,
which wraps to `255` for `uint8_t`. No dimension is ever selected, `min_elem` and
`max_elem` stay at 0, the cut value collapses to 0, every point lands on the
"greater" side, and the closed-range `[0, count-1]` Dutch-flag loop underflows
its `size_t` cursor to `SIZE_MAX`.

## The fix

* Select the cut dimension with a first-candidate flag instead of a negative
  sentinel — in `middleSplit_()` and in the incremental index's `buildBalanced()`,
  which had the very same `bestSpan = -1` pattern.
* Partition over the half-open range `[0, count)`, which cannot underflow.
* Compute the split midpoint as `low + (high - low) / 2` instead of
  `(low + high) / 2`, which overflows for wide integral coordinates.
* Promote the operands to `DistanceType` before subtracting them in L1 / L2 /
  L2_Simple, so unsigned coordinates do not wrap around (`detail::diff_as`).
* `static_assert` that `_DistanceType` is signed, as the adaptor docs already
  required. Non-arithmetic (user-defined) scalar types are still accepted.

## Differences with #314

#314 additionally changes the **default** `_DistanceType` of all five adaptors
and of the `metric_*` traits, from `T` to a metafunction mapping unsigned types
to `int64_t`/`double`. This PR deliberately does not, because:

* It is not needed to fix the reported crash — the original report already used
  an explicit `float` distance type.
* It silently changes a public associated type. `std::is_unsigned<char>` is also
  true on ARM, so `L2_Adaptor<char, ...>` would get a different `DistanceType`
  on aarch64 than on x86.
* `uint64_t -> double` cannot represent coordinates above 2^53, so the promotion
  is lossy exactly where it looks most helpful.
* Only the caller knows their coordinate range, so picking the distance type is
  arguably their call. The `static_assert` here makes the requirement explicit
  rather than guessing.

The cost is that `L2_Simple_Adaptor<uint8_t, Cloud>` no longer compiles — it
now says:

```
static assertion failed: nanoflann: _DistanceType must be signed. If ElementType
is unsigned (e.g. uint8_t), pass an explicit signed _DistanceType wide enough
for the squared distances of your coordinate range, for example:
L2_Simple_Adaptor<uint8_t, MyCloud, int32_t>.
```

That configuration previously crashed, so nothing that used to work breaks.

## Backwards compatibility

No default template argument, associated type, or public signature changes.
For every existing signed / floating-point element type, the new `diff_as` and
midpoint expressions are equivalent to the old ones. The only behavioral
difference is that with **signed integral** coordinates the midpoint now rounds
towards `low` rather than towards zero, which shifts tree shape slightly without
affecting query results.

## Testing

* 4 new tests: `unsigned_vs_bruteforce` (uint8/uint16/uint32 across L1, L2 and
  L2_Simple, with int32 / int64 / float / double distance types, checked against
  an exact double brute force, full `uint32_t` coordinate range),
  `unsigned_radius_search`, `unsigned_same_points` (degenerate all-equal case)
  and `unsigned_incremental_index`.
* The new tests segfault against the current `master` header, so they do pin
  the regression.
* Full suite passes under C++11, C++17 and C++20, and under ASan + UBSan.
* Clean build with `-Wall -Wextra -Wpedantic -Wconversion -Wshadow`; the four
  `-Wconversion` warnings that showed up for `DistanceType != ElementType`
  combinations are silenced with explicit casts.
* `clang-format-14` applied.

Fixes the issue reported in #314.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved KD-tree support for signed and unsigned integral coordinate types.
  - Prevented crashes, arithmetic overflow, and incorrect partitioning during index building and nearest-neighbor searches.
  - Added validation requiring signed distance types for unsigned coordinates.

- **Documentation**
  - Documented integral coordinate support, distance-type requirements, and custom metric usage.

- **Tests**
  - Added coverage for unsigned searches, radius filtering, duplicate points, and incremental queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->