### PR TITLE
CMake: Check for mtune=native flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,13 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 
   # Apply Release optimizations ONLY if it's not Debug and not Coverage
   if (NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND NOT "${CMAKE_BUILD_TYPE}" STREQUAL "Coverage")
-    add_compile_options(-O2 -mtune=native)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-mtune=native" HAS_MTUNE_NATIVE)
+    add_compile_options(-O2)
+    if(HAS_MTUNE_NATIVE)
+      add_compile_options(-mtune=native)
+    endif()
   endif()
-
   # Workaround: Eigen <3.4 produces *tons* of warnings in GCC >=6. See http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1221
   if (NOT ${CMAKE_CXX_COMPILER_VERSION} LESS "6.0")
     add_compile_options(-Wno-ignored-attributes -Wno-int-in-bool-context)


### PR DESCRIPTION
For some archs like ppc64 this is not always available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Release builds now use optimized compiler settings by default.
  * Hardware-specific tuning is enabled only when supported by the compiler, improving build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->